### PR TITLE
readme: add community packages/projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ If you don't want to set up a build environment, you can download Hyperapp from 
 <script src="https://unpkg.com/hyperapp"></script>
 ```
 
+### Starter Kits
+
+If you are looking to get started with a production app using a build setup quickly and easily, there are community starter kits to help.
+
+* [**Hyperapp Kit**](https://github.com/atomiks/hyperapp-kit) - A starter kit using [Parcel](https://parceljs.org/) that supports prerendering for improved inital page load performance.
+* [**Hyperapp One**](https://github.com/selfup/hyperapp-one) - A starter kit using [Webpack](https://webpack.js.org) for quickstarting an application with AirBnB's JavaScript Styleguide.
+
 ## Overview
 
 Hyperapp applications consist of three interconnected parts: the [state](#state), [view](#view), and [actions](#actions).
@@ -503,6 +510,14 @@ export const PlayerList = ({ players }) =>
 #### Top-Level Nodes
 
 Keys are not registered on the top-level node of your view. If you are toggling the top-level view, and you must use keys, wrap them in an unchanging node.
+
+## Packages
+
+The Hyperapp community has provided several packages for additional functionality to use with Hyperapp.
+
+* [**@hyperapp/router**](https://github.com/hyperapp/router) - Declarative routing for Hyperapp using the History API.
+* [**@hyperapp/transitions**](https://github.com/hyperapp/transitions) - Animate elements as they are appear, disappear and move around on the page.
+* [**@hyperapp/render**](https://github.com/hyperapp/render) - Render Hyperapp views to an HTML string.
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -81,13 +81,6 @@ If you don't want to set up a build environment, you can download Hyperapp from 
 <script src="https://unpkg.com/hyperapp"></script>
 ```
 
-### Starter Kits
-
-If you are looking to get started with a production app using a build setup quickly and easily, there are community starter kits to help.
-
-* [**Hyperapp Kit**](https://github.com/atomiks/hyperapp-kit) - A starter kit using [Parcel](https://parceljs.org/) that supports prerendering for improved inital page load performance.
-* [**Hyperapp One**](https://github.com/selfup/hyperapp-one) - A starter kit using [Webpack](https://webpack.js.org) for quickstarting an application with AirBnB's JavaScript Styleguide.
-
 ## Overview
 
 Hyperapp applications consist of three interconnected parts: the [state](#state), [view](#view), and [actions](#actions).
@@ -518,6 +511,13 @@ The Hyperapp community has provided several packages for additional functionalit
 * [**@hyperapp/router**](https://github.com/hyperapp/router) - Declarative routing for Hyperapp using the History API.
 * [**@hyperapp/transitions**](https://github.com/hyperapp/transitions) - Animate elements as they are appear, disappear and move around on the page.
 * [**@hyperapp/render**](https://github.com/hyperapp/render) - Render Hyperapp views to an HTML string.
+
+## Starter Kits
+
+If you are looking to get started with a production app using a build setup quickly and easily, there are community starter kits to help.
+
+* [**Hyperapp Kit**](https://github.com/atomiks/hyperapp-kit) - A starter kit using [Parcel](https://parceljs.org/) that supports prerendering for improved inital page load performance.
+* [**Hyperapp One**](https://github.com/selfup/hyperapp-one) - A starter kit using [Webpack](https://webpack.js.org) for quickstarting an application with AirBnB's JavaScript Styleguide.
 
 ## Links
 


### PR DESCRIPTION
I think there are some Hyperapp-related things currently missing from the docs. The README is seen as the one-stop source for everything Hyperapp (to me), so it makes sense that it should include these for visibility reasons.

### Starter Kit section

Why? Although beginners might use the "browser-only" method for toying around, they will want to also get started with a production app as well. Setting up Webpack can be difficult and they might not realise these exist. Linking to these starter kits lets them know there are ways get started with a build setup quickly.

### Packages section

Why? Solutions to common problems (routing, transitions, SSR) should be visible in the docs so readers know they exist without needing to externally search for them.