### PR TITLE
Add App interface

### DIFF
--- a/hyperapp.d.ts
+++ b/hyperapp.d.ts
@@ -78,6 +78,24 @@ export interface View<State, Actions> {
   (state: State, actions: Actions): VNode<object>
 }
 
+/** The interface for an application.
+ *
+ * @param state The state object.
+ * @param actions The actions object implementation.
+ * @param view The view function.
+ * @param container The DOM element where the app will be rendered to.
+ * @returns The actions wired to the application.
+ * @memberOf [App]
+ */
+export interface App<State, Actions> {
+  (
+    state: State,
+    actions: ActionsType<State, Actions>,
+    view: View<State, Actions>,
+    container: Element | null
+  ): Actions
+}
+
 /** The app() call creates and renders a new application.
  *
  * @param state The state object.


### PR DESCRIPTION
This PR proposes to add an `App` Typescript interface, which we will allow us to add type checking of some `app()` function as param. For example if we use [hyperapp/render](https://github.com/hyperapp/render) package.

This is motivated by this [hyperapp/render PR](https://github.com/hyperapp/render/pull/10) by @frenzzy that it needs an interface to check the `app()` function param.

E.g:

```ts

import { h, app, App, ActionsType, View } from "hyperapp"
import { withRender, Render } from "@hyperapp/render/node"

interface MyState {
  count: number
}

interface MyActions {
  up(value: number): MyState
}

const state: MyState = {
  count: 0
}

const actions: ActionsType<MyState, MyActions> = {
  up: (value: number) => state => ({
    count: state.count + value
  })
}

const view: View<MyState, MyActions> = (state, actions) => (
  <main>
    <button onclick={actions.up}>{state.count}</button>
  </main>
)

// here withRender() needs to check the app() function param via App interface
const myRender = withRender<App<MyState, MyActions>, Render<MyState, MyActions>>(app)(
  state,
  actions,
  view,
  document.body
)

console.log( myRender.toString() )
``` 

Ref: https://github.com/hyperapp/render/pull/10