### PR TITLE
Custom Elements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -321,6 +321,8 @@ export function app(state, actions, view, container) {
         (isSvg = isSvg || node.nodeName === "svg")
       )
 
+      if (node.nodeName.indexOf("-") !== -1) return element
+
       var oldKeyed = {}
       var newKeyed = {}
       var oldElements = []

--- a/test/recycling.test.js
+++ b/test/recycling.test.js
@@ -50,3 +50,25 @@ test("recycle markup against keyed vdom", done => {
     document.getElementById("app")
   )
 })
+
+test("recycle custom elements", done => {
+  const SSR_HTML = `<div id="app"><main><custom-element>foo</custom-element></main></div>`
+
+  document.body.innerHTML = SSR_HTML
+
+  app(
+    null,
+    null,
+    state => (
+      <main>
+        <custom-element
+          oncreate={() => {
+            expect(document.body.innerHTML).toBe(SSR_HTML)
+            done()
+          }}
+        />
+      </main>
+    ),
+    document.getElementById("app")
+  )
+})


### PR DESCRIPTION
Custom elements usually control their children nodes themselves and hyperapp should not touch them during hydration and lifecycle.

Fixes #757