### PR TITLE
add form attribute to readonly attributes list.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -194,6 +194,7 @@ export function app(state, actions, view, container) {
       } else if (
         name in element &&
         name !== "list" &&
+        name !== "form" &&
         name !== "type" &&
         name !== "draggable" &&
         name !== "spellcheck" &&

--- a/test/dom.test.js
+++ b/test/dom.test.js
@@ -648,6 +648,13 @@ testVdomToHtml("input list attribute", [
   }
 ])
 
+testVdomToHtml("input form attribute", [
+  {
+    vdom: <input form="foobar" />,
+    html: `<input form="foobar">`
+  }
+])
+
 testVdomToHtml("events", [
   {
     vdom: (


### PR DESCRIPTION
form attribute for input tag is readonly, so following errors occurred and nothing is rendered.

```
Uncaught TypeError: Cannot assign to read only property 'form'
 of object '#<HTMLInputElement>'
```

I also created codepen samples that fails for rendering.
https://codepen.io/middleearth/pen/EeJoyK

I think this issue is same as #179 , but i wondered this fix is correct.

please tell me if something is wrong.