### PR TITLE
ssr/hydration: keep markup created by custom elements in the dom

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -385,11 +385,14 @@ export function app(state, actions, view, container) {
         }
       }
 
-      while (i < oldChildren.length) {
-        if (getKey(oldChildren[i]) == null) {
-          removeElement(element, oldElements[i], oldChildren[i])
+      var isCustomElement = element.nodeName.indexOf("-") !== -1
+      if (!isRecycling && !isCustomElement) {
+        while (i < oldChildren.length) {
+          if (getKey(oldChildren[i]) == null) {
+            removeElement(element, oldElements[i], oldChildren[i])
+          }
+          i++
         }
-        i++
       }
 
       for (var i in oldKeyed) {

--- a/test/recycling.test.js
+++ b/test/recycling.test.js
@@ -50,3 +50,52 @@ test("recycle markup against keyed vdom", done => {
     document.getElementById("app")
   )
 })
+
+test("recycle custom-elements inner markup to support non-native shadowdom polyfills", done => {
+  const SSR_HTML = `<div id="app"><main><custom-element>fake shadowdom</custom-element></main></div>`
+
+  document.body.innerHTML = SSR_HTML
+
+  app(
+    null,
+    null,
+    state => (
+      <main>
+        <custom-element
+          oncreate={element => {
+            expect(element.innerHTML).toBe("fake shadowdom")
+            expect(document.body.innerHTML).toBe(SSR_HTML)
+            done()
+          }}
+        />
+      </main>
+    ),
+    document.getElementById("app")
+  )
+})
+
+test("hydrate custom elements children defined in the view", done => {
+  const SSR_HTML = `<div id="app"><main><custom-element><hr id="foo"></custom-element></main></div>`
+
+  document.body.innerHTML = SSR_HTML
+
+  app(
+    null,
+    null,
+    state => (
+      <main>
+        <custom-element>
+          <hr
+            id="foo"
+            oncreate={element => {
+              expect(element.id).toBe("foo")
+              expect(document.body.innerHTML).toBe(SSR_HTML)
+              done()
+            }}
+          />
+        </custom-element>
+      </main>
+    ),
+    document.getElementById("app")
+  )
+})


### PR DESCRIPTION
fixes the issue, that hyperapp throws out existing markup that is created by custom elements before the app is initialized.

In which scenarios does this matter?

**shadow dom polyfill**
Custom element code gets executed before hyperapp has hydrated the ssr markup. In browsers that don't support native shadow dom yet, its common to write the CEs private markup into the normal/light dom.

**custom element ssr**
There is no standard way to server render custom elements, but serveral frameworks or tools ([skates](https://github.com/skatejs/ssr), [stencil](https://stenciljs.com/docs/prerendering), [ssi](https://micro-frontends.org/#serverside-rendering--universal-rendering)) offer proprietary ways to prepolulate CE markup on the server side to improve seo and webperf.

I've added a condition to skip the existing-markup-cleaning-routine for custom elements in `patch()` in the first `isRecycling` run. This way existing markup that hyperapp did not expect stays intact and CE children that are explicitly stated in the view still get hydrated correctly.

I first tried to do the skipping in `recycleElement` as @zaceno suggested in #757. But by doing this, hyperapp would create double markup for CE child elements that are defined in the view instead of hydrating the existing elements (see testcases).
