### PR TITLE
Set text node type to Node.TEXT_NODE

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 var DEFAULT = 0
 var RECYCLED_NODE = 1
-var TEXT_NODE = 2
+var TEXT_NODE = 3 // Node.TEXT_NODE
 
 var XLINK_NS = "http://www.w3.org/1999/xlink"
 var SVG_NS = "http://www.w3.org/2000/svg"
@@ -417,7 +417,7 @@ var createTextVNode = function(text, element) {
 }
 
 var recycleChild = function(element) {
-  return element.nodeType === 3 // Node.TEXT_NODE
+  return element.nodeType === TEXT_NODE
     ? createTextVNode(element.nodeValue, element)
     : recycleElement(element)
 }


### PR DESCRIPTION
Fixes https://github.com/jorgebucaran/hyperapp/pull/726#discussion_r201364435

Would be nice to standardize VNode types as early as possible to be able to build third-party extensions which can rely on this type without the need to change them in the future.