### PR TITLE
Fix anoying error from interface Element not being able to implement …

### DIFF
--- a/hyperapp.d.ts
+++ b/hyperapp.d.ts
@@ -10,7 +10,7 @@ export interface VNode<Attributes = {}> {
   nodeName: string
   attributes?: Attributes
   children: Array<VNode | string>
-  key: string | number | null
+  key: string | number
 }
 
 /** A Component is a function that returns a custom VNode or View.

--- a/hyperapp.d.ts
+++ b/hyperapp.d.ts
@@ -10,7 +10,7 @@ export interface VNode<Attributes = {}> {
   nodeName: string
   attributes?: Attributes
   children: Array<VNode | string>
-  key: string
+  key: string | number | null
 }
 
 /** A Component is a function that returns a custom VNode or View.


### PR DESCRIPTION
…VNode and ReactElement simultaneously due to Key.
Basically, I was having the following error:
```
 Interface 'Element' cannot simultaneously extend types 'VNode<any>' and 'ReactElement<any>'.
  Named property 'key' of types 'VNode<any>' and 'ReactElement<any>' are not identical.
```

This pull request fixes it.