### PR TITLE
Fix typings comply vnode

### DIFF
--- a/hyperapp.d.ts
+++ b/hyperapp.d.ts
@@ -10,7 +10,7 @@ export interface VNode<Attributes = {}> {
   nodeName: string
   attributes?: Attributes
   children: Array<VNode | string>
-  key: string | number
+  key: string | number | null
 }
 
 /** A Component is a function that returns a custom VNode or View.

--- a/hyperapp.d.ts
+++ b/hyperapp.d.ts
@@ -10,7 +10,7 @@ export interface VNode<Attributes = {}> {
   nodeName: string
   attributes?: Attributes
   children: Array<VNode | string>
-  key: string | number | null
+  key: string | number
 }
 
 /** A Component is a function that returns a custom VNode or View.


### PR DESCRIPTION
We really need `null` type, as `React.Key` has `number` and `null`, and if we can't have the same React.Key types, we cannot exted VNode from React.

Sorry @jorgebucaran  we do need null...
```
[at-loader] ./node_modules/hyperapp/hyperapp.d.ts:101:15 
    TS2320: Interface 'Element' cannot simultaneously extend types 'VNode<any>' and 'ReactElement<any>'.
  Named property 'key' of types 'VNode<any>' and 'ReactElement<any>' are not identical. 
```