### PR TITLE
make our virtual DOM a little bit "purer" by using Object.create(null)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -402,14 +402,15 @@ var patchElement = function(
 }
 
 var createVNode = function(name, props, children, element, key, type) {
-  return {
+  var pureVNode = Object.create(null)
+  return Object.assign(pureVNode, {
     name: name,
     props: props,
     children: children,
     element: element,
     key: key,
     type: type
-  }
+  })
 }
 
 var createTextVNode = function(text, element) {

--- a/src/index.js
+++ b/src/index.js
@@ -402,15 +402,14 @@ var patchElement = function(
 }
 
 var createVNode = function(name, props, children, element, key, type) {
-  var pureVNode = Object.create(null)
-  return Object.assign(pureVNode, {
+  return {
     name: name,
     props: props,
     children: children,
     element: element,
     key: key,
     type: type
-  })
+  }
 }
 
 var createTextVNode = function(text, element) {
@@ -463,7 +462,7 @@ export var h = function(name, props) {
     if(rest.length <= 0) rest.push(...props)
     props = {}
   }
-
+  
   if ((props = props == null ? {} : props).children != null) {
     if (rest.length <= 0) {
       rest.push(props.children)


### PR DESCRIPTION
We could make our virtual DOM a little bit "purer" by using Object.create(null). This will create a truly plain object that doesn't inherit from Object but null instead.