### PR TITLE
Update effect and subscription signatures

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -482,7 +482,7 @@ export var h = function(name, props) {
 }
 
 var cancel = function(sub) {
-  sub.cancel()
+  sub[1][2]()
 }
 
 var isSameValue = function(a, b) {
@@ -503,8 +503,7 @@ var isSameAction = function(a, b) {
 
 var restart = function(sub, oldSub, dispatch) {
   for (var k in merge(sub, oldSub)) {
-    if (k === "cancel") {
-    } else if (sub[k] === oldSub[k] || isSameAction(sub[k], oldSub[k])) {
+    if (sub[k] === oldSub[k] || isSameAction(sub[k], oldSub[k])) {
     } else {
       cancel(oldSub)
       return start(sub, dispatch)
@@ -514,31 +513,33 @@ var restart = function(sub, oldSub, dispatch) {
 }
 
 var start = function(sub, dispatch) {
-  return merge(sub, {
-    cancel: sub.effect(sub, dispatch)
-  })
+  return [
+    sub[0],
+    sub[1],
+    sub[0](sub[1], dispatch)
+  ]
 }
 
 var refresh = function(sub, oldSub, dispatch) {
-  if (isArray(sub) || isArray(oldSub)) {
-    var out = []
-    var subs = isArray(sub) ? sub : [sub]
-    var oldSubs = isArray(oldSub) ? oldSub : [oldSub]
+  var current = [].concat(sub);
+  var previous = [].concat(oldSub);
+  var out = [];
 
-    for (var i = 0; i < subs.length || i < oldSubs.length; i++) {
-      out.push(refresh(subs[i], oldSubs[i], dispatch))
-    }
-
-    return out
+  for(var i = 0; i < current.length || i < previous.length; i++) {
+    var cSub = current[i];
+    var pSub = previous[i];
+    out.push(
+      cSub
+        ? pSub
+          ? restart(cSub, pSub, dispatch)
+          : start(cSub, dispatch)
+        : pSub
+          ? cancel(pSub)
+          : pSub
+    );
   }
 
-  return sub
-    ? oldSub
-      ? restart(sub, oldSub, dispatch)
-      : start(sub, dispatch)
-    : oldSub
-      ? cancel(oldSub)
-      : oldSub
+  return out;
 }
 
 export function app(props) {

--- a/src/index.js
+++ b/src/index.js
@@ -570,7 +570,7 @@ export function app(props) {
       if (typeof obj[0] === "function") {
         dispatch(obj[0](state, obj[1], data))
       } else {
-        obj[1].effect(obj[1], dispatch, setState(obj[0]))
+        obj[1][0](obj[1][1], dispatch, setState(obj[0]))
       }
     } else {
       setState(obj)

--- a/test/effect.test.js
+++ b/test/effect.test.js
@@ -1,0 +1,20 @@
+import { app } from '../src'
+
+test('runs an effect', () => {
+  var resolve = null
+
+  var promise = new Promise((a) => {
+    resolve = a;
+  })
+
+  var myEffect = function (fx) {
+    resolve(fx.text)
+  }
+
+  app({
+    init: [{}, { effect: myEffect, text: 'foo' }],
+    container: { children: [] }
+  })
+
+  return expect(promise).resolves.toBe('foo')
+});

--- a/test/effect.test.js
+++ b/test/effect.test.js
@@ -7,12 +7,12 @@ test('runs an effect', () => {
     resolve = a;
   })
 
-  var myEffect = function (fx) {
-    resolve(fx.text)
+  var myEffect = function (arg) {
+    resolve(arg)
   }
 
   app({
-    init: [{}, { effect: myEffect, text: 'foo' }],
+    init: [{}, [myEffect, 'foo']],
     container: { children: [] }
   })
 

--- a/test/subscriptions.test.js
+++ b/test/subscriptions.test.js
@@ -1,0 +1,59 @@
+import { app, h } from '../src';
+
+var merge = function(a, b) {
+  var target = {}
+
+  for (var i in a) target[i] = a[i]
+  for (var i in b) target[i] = b[i]
+
+  return target
+}
+
+test('runs a subscription', () => {
+  var resolve = null;
+  var promise = new Promise(function (a) {
+    resolve = a
+  })
+
+  var mySubscription = function(props) {
+    return merge(
+      props,
+      {
+        effect: (args, dispatch) => {
+          var fire = () => {
+            dispatch(args.action, {})
+          }
+
+          var interval = setInterval(fire, args.every)
+
+          return function () {
+            clearInterval(interval)
+          }
+        }
+      }
+    )
+  }
+
+  var tickAction = function(_, state) {
+    var count = state.count + 1
+    return [
+      merge(state, { count: count }),
+      state.count < 5 ? null : [myEndEffect, 'foo']
+    ]
+  }
+
+  var myEndEffect = props => resolve(props[1]);
+
+  app({
+    init: { count: 0 },
+    subscriptions: state => [
+      state.count < 5 && mySubscription({
+        action: tickAction,
+        every: 5
+      }),
+    ]
+  })
+
+  return expect(promise).resolves.toBe('foo')
+});
+

--- a/test/subscriptions.test.js
+++ b/test/subscriptions.test.js
@@ -15,43 +15,36 @@ test('runs a subscription', () => {
     resolve = a
   })
 
-  var mySubscription = function(props) {
-    return merge(
-      props,
-      {
-        effect: (args, dispatch) => {
-          var fire = () => {
-            dispatch(args.action, {})
-          }
+  var mySubEffect = function(args, dispatch) {
+    var fire = () => {
+      dispatch(args.action, {})
+    }
 
-          var interval = setInterval(fire, args.every)
+    var interval = setInterval(fire, args.every)
 
-          return function () {
-            clearInterval(interval)
-          }
-        }
-      }
-    )
+    return function () {
+      clearInterval(interval)
+    }
   }
+
+  var max = 5
 
   var tickAction = function(_, state) {
     var count = state.count + 1
     return [
       merge(state, { count: count }),
-      state.count < 5 ? null : [myEndEffect, 'foo']
+      state.count < max ? null : [myEndEffect, 'foo']
     ]
   }
 
-  var myEndEffect = props => resolve(props[1]);
+  var myEndEffect = props => resolve(props);
 
   app({
     init: { count: 0 },
     subscriptions: state => [
-      state.count < 5 && mySubscription({
-        action: tickAction,
-        every: 5
-      }),
-    ]
+      state.count < max && [mySubEffect, { action: tickAction, every: 5 }],
+    ],
+    container: { children: [] }
   })
 
   return expect(promise).resolves.toBe('foo')


### PR DESCRIPTION
## Tasks

 - [x] Implement tuple-based effects
 - [x] Implement tuple-based subscriptions

## Discussion

 - [Part of issue 765](https://github.com/jorgebucaran/hyperapp/issues/765#issuecomment-426542026)

## Changes

### Effects

#### Current V2 Effects:

```js
{ effect: someEffectFunction, ...otherParams }
```

#### Changes for V2 Effects:

```js
[someEffectFunction, { ...otherParams }]
```

### Subscriptions

#### Current V2 Subscriptions:

```js
subscriptions: state => [
  { effect: someSubscriptionEffect, ...otherParams, cancel: injectedCancelFn },
]
```

#### Changes for V2 Subscriptions:

```js
subscriptions: state => [
  [someSubscriptionEffect, { ...otherParams }, injectedCancelFn],
]
```

#### Other notable changes for subscriptions:

 - Previous implementation allowed infinite array nesting, this implementation requires a flat list of subscription tuples.

 