### PR TITLE
Bump babel version and config so jest passes

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,12 @@
     "release": "npm run build && npm test && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"
   },
   "babel": {
-    "presets": ["env"],
+    "presets": [
+      "@babel/env"
+    ],
     "plugins": [
       [
-        "transform-react-jsx",
+        "@babel/transform-react-jsx",
         {
           "pragma": "h"
         }
@@ -42,13 +44,14 @@
     ]
   },
   "devDependencies": {
-    "babel-plugin-transform-react-jsx": "^6.24.1",
-    "babel-preset-env": "^1.7.0",
+    "@babel/core": "^7.0.0-0",
+    "@babel/preset-env": "^7.3.1",
+    "@babel/plugin-transform-react-jsx": "^7.3.0",
     "jest": "^24.1.0",
     "prettier": "^1.16.4",
     "rollup": "^1.2.2",
-    "typescript": "3.3.3",
-    "terser": "^3.16.1"
+    "terser": "^3.16.1",
+    "typescript": "3.3.3"
   },
   "prettier": {
     "semi": false


### PR DESCRIPTION
## Tasks

 - [x] Update babel to 7
 - [x] Update babel config so jest passes

## Notes

I was seeing this error locally and on ci:

```
npm test

> hyperapp@2.0.0-alpha.2 test /Users/alex/code/projects/hyperapp
> jest --coverage --no-cache && tsc -p test/ts

 FAIL  test/h.test.js
  ● Test suite failed to run

    Unknown substitution "BODY" given

      at Object.keys.forEach.key (node_modules/@babel/template/lib/populate.js:35:15)
          at Array.forEach (<anonymous>)
      at populatePlaceholders (node_modules/@babel/template/lib/populate.js:33:31)
      at arg (node_modules/@babel/template/lib/string.js:22:51)
      at arg (node_modules/@babel/template/lib/builder.js:77:14)
      at spec (node_modules/babel-plugin-transform-es2015-for-of/lib/index.js:171:20)
      at PluginPass.ForOfStatement (node_modules/babel-plugin-transform-es2015-for-of/lib/index.js:76:21)
      at newFn (node_modules/@babel/traverse/lib/visitors.js:193:21)
      at NodePath._call (node_modules/@babel/traverse/lib/path/context.js:53:20)
      at NodePath.call (node_modules/@babel/traverse/lib/path/context.js:40:17)
          =============
      at exports.default (node_modules/babel-plugin-transform-es2015-for-of/lib/index.js:14:20)
      at loadDescriptor (node_modules/@babel/core/lib/config/full.js:165:14)
      at cachedFunction (node_modules/@babel/core/lib/config/caching.js:33:19)
      at loadPluginDescriptor (node_modules/@babel/core/lib/config/full.js:200:28)
      at config.plugins.reduce (node_modules/@babel/core/lib/config/full.js:69:20)
          at Array.reduce (<anonymous>)
      at recurseDescriptors (node_modules/@babel/core/lib/config/full.js:67:38)
      at recurseDescriptors (node_modules/@babel/core/lib/config/full.js:94:27)

----------|----------|----------|----------|----------|-------------------|
File      |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
----------|----------|----------|----------|----------|-------------------|
All files |        0 |        0 |        0 |        0 |                   |
----------|----------|----------|----------|----------|-------------------|
Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        1.79s
Ran all test suites.
```