### PR TITLE
Lifecycle hooks as Events (no delayed remove)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,10 @@ var SVG_NS = "http://www.w3.org/2000/svg"
 var EMPTY_OBJECT = {}
 var EMPTY_ARRAY = []
 
+var CREATE_EVENT = new Event('create')
+var UPDATE_EVENT = new Event('update')
+var REMOVE_EVENT = new Event('remove')
+
 var map = EMPTY_ARRAY.map
 var isArray = Array.isArray
 
@@ -104,9 +108,9 @@ var createElement = function(node, lifecycle, eventProxy, isSvg) {
       : document.createElement(node.name)
 
   var props = node.props
-  if (props.onCreate) {
+  if (props.oncreate) {
     lifecycle.push(function() {
-      props.onCreate(element)
+      element.dispatchEvent(CREATE_EVENT)
     })
   }
 
@@ -154,10 +158,10 @@ var updateElement = function(
     }
   }
 
-  var cb = isRecycled ? nextProps.onCreate : nextProps.onUpdate
+  var cb = isRecycled ? nextProps.oncreate : nextProps.onupdate
   if (cb != null) {
     lifecycle.push(function() {
-      cb(element, lastProps)
+      element.dispatchEvent(UPDATE_EVENT)
     })
   }
 }
@@ -167,25 +171,15 @@ var removeChildren = function(node) {
     removeChildren(node.children[i])
   }
 
-  var cb = node.props.onDestroy
-  if (cb != null) {
-    cb(node.element)
+  if (node.props.onremove != null) {
+    node.element.dispatchEvent(REMOVE_EVENT)
   }
 
   return node.element
 }
 
 var removeElement = function(parent, node) {
-  var remove = function() {
-    parent.removeChild(removeChildren(node))
-  }
-
-  var cb = node.props && node.props.onRemove
-  if (cb != null) {
-    cb(node.element, remove)
-  } else {
-    remove()
-  }
+  parent.removeChild(removeChildren(node))
 }
 
 var getKey = function(node) {


### PR DESCRIPTION
I shared a snippet of an alternative approach to lifecycle hooks I have been playing with in a fork of V2 being used on personal project of mine. This raised a few questions and a more detailed explanation was requested, so here is the implementation. A couple of things are assumed:

- Firstly @frenzzy suggested that:
> I think delayed remove is not needed, but oncreate and ondestroy are important https://hyperapp.slack.com/archives/C41ECC0V6/p1551190367214200

I'm not sure how you can do transition out style animations without them? But removing this certainly [simplifies](https://github.com/jorgebucaran/hyperapp/compare/V2...lukejacksonn:V2#diff-1fdf421c05c1140f6d71444ea2b27638L179) hyperapp core so `onRemove` is omitted here.

- Secondly by nature of the implementation the remaining lifecycle events get treated like any user interaction (like `onclick` for example) and so now have the same signature and behave the same:

```js
oncreate | onupdate | onremove:  (state, e) => ...,
```

~I will create a codepen for this build now.~ Here is a demo on [CodePen](https://codepen.io/lukejacksonn/pen/EMawmX?editors=0010).