### PR TITLE
Fix bug with Lazy when used in JSX

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -462,7 +462,7 @@ export var h = function(name, props) {
   }
 
   return typeof name === "function"
-    ? name(props, (props.children = children))
+    ? name(props, name !== Lazy && (props.children = children))
     : createVNode(name, props, children, null, props.key, DEFAULT_NODE)
 }
 


### PR DESCRIPTION
When Lazy is passed through `h` (like when used in JSX), it was being assigned a `children` property, set to an empty array.

This unnecessary "children" property was preventing the `shouldUpdate` function from returning `false` when it should have.