### PR TITLE
Build hyperapp to root instead of dist

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -16,6 +16,7 @@ coverage
 
 # Dist
 *.gz
-hyperapp.js
-hyperapp.js.map
+dist/
 
+# Not necessary for distribution
+.travis.yml

--- a/package.json
+++ b/package.json
@@ -2,14 +2,13 @@
   "name": "hyperapp",
   "description": "JavaScript micro-framework for building web applications.",
   "version": "2.0.0-alpha.10",
-  "main": "dist/hyperapp.js",
+  "main": "hyperapp.js",
   "module": "src/index.js",
   "license": "MIT",
   "repository": "jorgebucaran/hyperapp",
   "homepage": "https://github.com/jorgebucaran/hyperapp",
   "files": [
-    "src",
-    "dist"
+    "src"
   ],
   "author": "Jorge Bucaran",
   "keywords": [
@@ -22,8 +21,8 @@
   "scripts": {
     "test": "exit",
     "build": "npm run bundle && npm run minify",
-    "bundle": "rollup -i src/index.js -o dist/hyperapp.js --no-esModule -m -f umd -n hyperapp",
-    "minify": "terser dist/hyperapp.js -o dist/hyperapp.js -mc --source-map includeSources,url=hyperapp.js.map",
+    "bundle": "rollup -i src/index.js -o hyperapp.js --no-esModule -m -f umd -n hyperapp",
+    "minify": "terser hyperapp.js -o hyperapp.js -mc --source-map includeSources,url=hyperapp.js.map",
     "prepare": "npm run build",
     "release": "npm run build && npm test && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"
   },


### PR DESCRIPTION
## Summary

 - Add npmignore to prevent some files from being published to npm
 - Update gitignore now that there is deviation between git and npm ignore lists
 - Update scripts to target root rather than dist

## Benefits

This will allow browsers and nodejs to include things like `import { interval } from 'hyperapp/time';` or `import { interval } from 'https://unpkg.com/hyperapp@2.0.0-alpha.X/time`.