### PR TITLE
Initial TypeScript declarations for V2 API.

### DIFF
--- a/hyperapp.d.ts
+++ b/hyperapp.d.ts
@@ -1,0 +1,149 @@
+export as namespace hyperapp;
+
+
+/** @namespace [VDOM] */
+
+/** The VDOM representation of an Element.
+ *
+ * @memberOf [VDOM]
+ */
+export interface VNode<Attributes = {}> {
+    nodeName: string;
+    attributes?: Attributes;
+    children: (VNode | string)[];
+    key: string | number | null;
+}
+
+/**
+ * Possibles children types
+ */
+export type Children = VNode | string | number | null
+
+/** A Component is a function that returns a custom VNode or View.
+ *
+ * @memberOf [VDOM]
+ */
+export interface Component<Attributes = {}> {
+    (attributes: Attributes, children: Children[]): VNode<Attributes>;
+}
+
+/** The soft way to create a VNode.
+ * @param name      An element name or a Component function
+ * @param attributes     Any valid HTML atributes, events, styles, and meta data
+ * @param children  The children of the VNode
+ * @returns A VNode tree.
+ *
+ * @memberOf [VDOM]
+ */
+export function h<Attributes>(
+    nodeName: Component<Attributes> | string,
+    attributes?: Attributes,
+    ...children: (Children | Children[])[]
+): VNode<Attributes>
+
+/** @namespace [App] */
+
+/** An effect as the result of an ation
+ * 
+ * @memberOf [App]
+ */
+export type Dispatch<State> = <Data = {}, Props=void>(obj: Action<State, Data, Props> | State, data: Data) => void;
+
+
+/** An effect as the result of an ation
+ * 
+ * @memberOf [App]
+ */
+export type EffectFunc<State, Props, Result = void> = (props: Props, dispatch: Dispatch<State>) => Result;
+
+/** An effect as the result of an ation
+ * 
+ * @memberOf [App]
+ */
+export type Effect<State, Props> = [EffectFunc<State, Props>, Props];
+
+/** The result of an action.
+ *
+ * @memberOf [App]
+ */
+export type ActionResult<State> = State | [State, ...Effect<State, unknown>[]];
+
+/** The interface for a single action implementation.
+ *
+ * @memberOf [App]
+ */
+export type ActionFunc<State, Data = {}, Props = undefined> =
+    Props extends void ? ((state: State, data: Data) => ActionResult<State>) : ((state: State, props: Props, data: Data) => ActionResult<State>);
+
+/** A reference to an action to be invoked by Hyperapp, with optional additional parameters
+ * 
+ * @memberOf [App]
+ */
+export type Action<State, Data = {}, Props = undefined> =
+    Props extends void ? ActionFunc<State, Data, Props> : [ActionFunc<State, Data, Props>, Props]
+
+/** A reference to an subscription to be managed by Hyperapp, with optional additional parameters
+ * 
+ * @memberOf [App]
+ */
+export type Subscription<State, Props = any> = [EffectFunc<State, Props, () => void>, Props];
+
+/**
+ * A function used to create a particular subscription.
+ * 
+ * @memberOf [App]
+ */
+export type SubscriptionConstructor<State, Props = {}> = (props: Props) => Subscription<State, Props>
+
+
+/** The view function describes the application UI as a tree of VNodes.
+ * @returns A VNode tree.
+ * @memberOf [App]
+ */
+export interface View<State> {
+    (state: State): VNode<object> | null;
+}
+
+/** The possible response types for the subscription callback for an application
+ * 
+ * @memberOf [App]
+ */
+export type SubscriptionsResult<State> = | (Subscription<State> | boolean)[] | Subscription<State>;
+
+/** The subscriptions function describes the current application subscriptions.
+ * @returns The current subscription(s) given the current state
+ * @memberOf [App]
+ */
+export type Subscriptions<State> = (state: State) => SubscriptionsResult<State>;
+
+/** The set of properties that define a Hyperapp application.
+ * @memberOf [App]
+ */
+export interface App<State> {
+    init?: (() => State) | State;
+    view: View<State>;
+    container?: Element;
+    subscriptions: Subscriptions<State>;
+}
+
+/** The app() call creates and renders a new application.
+ *
+ * @param state The state object.
+ * @param actions The actions object implementation.
+ * @param view The view function.
+ * @param container The DOM element where the app will be rendered to.
+ * @returns The actions wired to the application.
+ * @memberOf [App]
+ */
+export function app<State>(app: App<State>): void
+
+// /** @namespace [JSX] */
+
+declare global {
+    namespace JSX {
+        interface Element extends VNode<any> {}
+        interface IntrinsicElements {
+            [elemName: string]: any;
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "version": "2.0.0-alpha.10",
   "main": "dist/hyperapp.js",
   "module": "src/index.js",
+  "typings": "hyperapp.d.ts",
   "license": "MIT",
   "repository": "jorgebucaran/hyperapp",
   "homepage": "https://github.com/jorgebucaran/hyperapp",
   "files": [
     "src",
-    "dist"
+    "dist",
+    "hyperapp.d.ts"
   ],
   "author": "Jorge Bucaran",
   "keywords": [


### PR DESCRIPTION
- Add new subscriptions API.
- Add new Effects API.
- Refactor Actions API to account for changes.
- Refactor `app` to account for changes.

Some outstanding potential items for discussion:

[ ] - I used conditional types to account for bare `SomeAction` versus tuple `[SomeAction, actionProps]` style of actions, which seems to work nicely. The only caveat that I seem to have found is the no-props version requires explicitly specifying the generic parameter to the effect constructor, e.g. `observe<void>(MyAction)` versus the inferred `observe([MyAction, someProps])` which infers the proper `observe<MyPropType>([MyAction, someProps])`. The advantage of the conditional types is you can't mistakenly omit props for an action that requires them and vice versa. I *believe* TypeScript is incorrectly inferring the `data` parameter in the non-props `ActionFunc` to be the attributes and that we've omitted the final `data` parameter. If you attemept to omit the `<void>` it infers the type to be the type from the `data` parameter.
[ ] - I renamed a few types, e.g. `ActionType` -> `Action`, to be consistent with other naming of `Effect` and `Subscription` types.
[ ] - I used `Props` for the generic argument in the `Action`, `Effect`, and `Subscription` types, since that's the language used in the various RFCs on here about the V2 APIs. Happy to change back to `Attributes` if requested.

Thanks for the work on this!