### PR TITLE
Fix createClass index var name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ var createClass = function(obj) {
   } else {
     for (var k in obj) {
       if (obj[k]) {
-        out += (out && " ") + i
+        out += (out && " ") + k
       }
     }
   }


### PR DESCRIPTION
Thank you for publishing Hyperapp 2.0.0-beta.1. Unfortunately, this version(v2.0.0-beta.1) does not work when I use HTML class attribute. This PR fixs that issue.

---
Example: 
```js
import { h } from "hyperapp";

export const Layout = (_, children) => <div class={{ red: true }}>{children}</div>;
```

Error message:
```
Uncaught ReferenceError: i is not defined
    at createClass (index.js:25)
    at patchProperty (index.js:117)
    at patch (index.js:195)
    at render (index.js:467)
```

https://github.com/jorgebucaran/hyperapp/commit/64d0e86d3885e9ff622af2f773eda6a112b6ec79#diff-1fdf421c05c1140f6d71444ea2b27638R27