### PR TITLE
Detached state fix (subscriptions)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -431,12 +431,12 @@ export var app = function(props, enhance) {
 
   var setState = function(newState) {
     if (state !== newState) {
+      state = newState
       if (subscriptions) {
         subs = patchSubs(subs, batch([subscriptions(newState)]), dispatch)
       }
       if (!lock) defer(render, (lock = true))
-    }
-    return (state = newState)
+    } else return state
   }
 
   var dispatch = (enhance ||


### PR DESCRIPTION
State wasn't properly set for subscriptions after [moving from render func](https://github.com/jorgebucaran/hyperapp/commit/5e2b64a4977b7b574e4ab3bc1a6eb393b934c7e6). 
When state updated and `patchSubs(subs, batch([subscriptions(newState)]), dispatch)` was running, 
`dispatch` function still used old state value (kinda detached state)
As result subscriptions with immediately dispatched actions run into `maximum call stack`