### PR TITLE
Fix the first example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Don't want to set up a build step? Import Hyperapp in a `<script>` tag as a modu
 
 ```html
 <script type="module">
-  import { h, app } from "https://unpkg.com/hyperapp"
+  import { h, app } from "https://unpkg.com/hyperapp@beta"
 </script>
 ```
 
@@ -82,7 +82,7 @@ First, create a new `index.html` file and paste the following code in it.
 <html lang="en">
   <head>
     <script type="module">
-      import { h, app } from "https://unpkg.com/hyperapp"
+      import { h, app } from "https://unpkg.com/hyperapp@beta"
 
       app({
         init: () => 0,


### PR DESCRIPTION
I'm not sure why but the default import `import { h, app } from "https://unpkg.com/hyperapp"` doesn't work. 
I get: `SyntaxError: import not found: app`

I can fix the import by changing it to `import { h, app } from "https://unpkg.com/hyperapp?module"`
but I get a **blank page** and no error to debug it. 🤷‍♂ 

What works for me is: 
`import { h, app } from "https://unpkg.com/hyperapp@beta"`