### PR TITLE
Give subscriptions a deferred version of dispatch

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,7 @@ var shouldRestart = function(a, b) {
 }
 
 var patchSubs = function(oldSubs, newSubs, dispatch) {
+  var deferredDispatch = function (action, props, obj) { setTimeout(dispatch, 0, action, props, obj); };
   for (
     var i = 0, oldSub, newSub, subs = [];
     i < oldSubs.length || i < newSubs.length;
@@ -79,7 +80,7 @@ var patchSubs = function(oldSubs, newSubs, dispatch) {
           ? [
               newSub[0],
               newSub[1],
-              newSub[0](dispatch, newSub[1]),
+              newSub[0](deferredDispatch, newSub[1]),
               oldSub && oldSub[2]()
             ]
           : oldSub


### PR DESCRIPTION
## Summary

Subscriptions with an immediate action/state dispatch cause patchSub to go into an infinite loop.
To prevent this, I gave subscriptions a copy of dispatch that defers for 0ms (next tick).

## Possible issues

 - Prevents dispatch from returning the current state in subscriptions
 - May introduce unexpected behaviour in subscriptions
 - May conflict with #844 ?

## Tickets

 - Issue #857 