### PR TITLE
fallback 'requestAnimationFrame'  to 'Timeout'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,9 @@ var EMPTY_OBJ = {}
 var EMPTY_ARR = []
 var map = EMPTY_ARR.map
 var isArray = Array.isArray
-var defer = requestAnimationFrame || setTimeout
+var defer = typeof requestAnimationFrame !== 'undefined' 
+  ? requestAnimationFrame 
+  : setTimeout
 
 var createClass = function(obj) {
   var out = ""


### PR DESCRIPTION
When running hyperapp#2 at env that doesn't provide 'requestAnimationFrame' function, 
you could expect that `var defer = requestAnimationFrame || setTimeout` will fallback 'defer' to timeout. But it's not, instead you get 'Reference Error' (by trying to get **undeclared** 'requestAnimationFrame').
This PR makes proper 'requestAnimationFrame' check and 'setTimeout' fallback