### PR TITLE
make patchSubs async

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -439,9 +439,6 @@ export var app = function(props) {
   var setState = function(newState) {
     if (state !== newState) {
       state = newState
-      if (subscriptions) {
-        subs = patchSubs(subs, batch([subscriptions(state)]), dispatch)
-      }
       if (view && !lock) defer(render, (lock = true))
     }
     return state
@@ -468,6 +465,9 @@ export var app = function(props) {
 
   var render = function() {
     lock = false
+    if (subscriptions) {
+      subs = patchSubs(subs, batch([subscriptions(state)]), dispatch)
+    }
     node = patch(
       node.parentNode,
       node,


### PR DESCRIPTION
Calling patchSubs directly in setState without deferring makes the `onAnimationFrame` subscription behave in strange ways. For example, this codepen doesn't work: https://codepen.io/zaceno/pen/vzMbLQ?editors=0010 Also, issue #868 is probably related. 

This PR moves `patchSubs`  back to where it used to be, inside `render` and thus makes it async. Merging this would make the codepen above work.