### PR TITLE
Fix events subs

### DIFF
--- a/lib/events/src/index.js
+++ b/lib/events/src/index.js
@@ -1,15 +1,15 @@
-var fx = function(a) {
-  return function(b) {
-    return [a, b]
+var sub = function(fn) {
+  return function(action) {
+    return [fn, {action: action}]
   }
 }
 
 var throttledEvent = function(name) {}
 
 var rawEvent = function(name) {
-  return fx(function(dispatch, action) {
+  return sub(function(dispatch, props) {
     var listener = function(event) {
-      dispatch(action, event)
+      dispatch(props.action, event)
     }
     addEventListener(name, listener)
     return function() {
@@ -41,10 +41,10 @@ export var onFocus = rawEvent("focus")
 export var onBlur = rawEvent("blur")
 
 // AnimationFrame
-export var onAnimationFrame = fx(function(dispatch, action) {
+export var onAnimationFrame = sub(function(dispatch, props) {
   var id = requestAnimationFrame(function frame(timestamp) {
     id = requestAnimationFrame(frame)
-    dispatch(action, timestamp)
+    dispatch(props.action, timestamp)
   })
   return function() {
     cancelAnimationFrame(id)
@@ -62,6 +62,11 @@ export var targetValue = function(event) {
   return event.target.value
 }
 
+var fx = function(a) {
+  return function(b) {
+    return [a, b]
+  }
+}
 export var eventOptions = fx(function(dispatch, props) {
   if (props.preventDefault) props.event.preventDefault()
   if (props.stopPropagation) props.event.stopPropagation()


### PR DESCRIPTION
`patchSubs` expects subscriptions to be of the form `[subFn, {...props...}]` because it wants to merge props-objects

In lib/events/src/index.js, subscriptions were being generated as `[subFn, actionFn]`, which caused behavior where subscriptions were being continually restarted. 

This PR fixes those subscriptions to generate `[subFn, {action: actionFn}]` (and for corresponding subscription functions to expect an object, not an action, as second argument).

At this time, as far as I can tell, only subscriptions in events need this treatement.