### PR TITLE
Make app return kill func

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -481,4 +481,8 @@ export var app = function(props) {
   }
 
   dispatch(props.init)
+
+  return function () {
+    patchSubs(subs, EMPTY_ARR, dispatch = Function)
+  }
 }


### PR DESCRIPTION
Main idea: make it possible for apps to die like things usually do: the corpse (the DOM nodes) are still there, but do nothing. Subscriptions are shut off as well.

usage:

```
const kill = app({...})
setTimeout(kill, 5000) //the app just stops doing anything after five seconds
```

There was a thought to return an object, where `kill` would be the only prop, as a way of future-proofing (in case we want to add other things to app's return in the future, without breaking existing code).

I think it's a good idea but could use some discussion, so for this initial submission I decided to just return the kill function, sidestepping the naming discussion and keeping the bundle-size addition minimal.