### PR TITLE
Allow chaining payload filters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -454,7 +454,7 @@ export var app = function(props) {
     return typeof action === "function"
       ? dispatch(action(state, props))
       : isArray(action)
-      ? typeof action[0] === "function"
+      ? typeof action[0] === "function" || isArray(action[0])
         ? dispatch(
             action[0],
             typeof action[1] === "function" ? action[1](props) : action[1]


### PR DESCRIPTION
### What this is: 

Today when you dispatch `([FooAction, 'baz'], 'bar')` it resolves to `dispatch(FooAction, 'baz')`, and when you dispatch `([FooAction, fn], 'bar')` it resolves to `dispatch(FooAction, fn('bar'))`. 

However, that _only_ works if `FooAction` is a function. If `FooAction` is an array, you get an error thrown at you. 

This teensy fix allows you to stack multiple payload processors on top of eachother, so that 

`([[[FooAction, fn1], fn2], fn3], 'bar')`

will resolve first to `dispatch([[FooAction, fn1], fn2], fn3('bar'))`

then to `dispatch([FooAction, fn1], fn2(fn3('bar')))`

and then (as it works today) `dispatch(FooAction, fn1(fn2(fn3('bar'))))`

### Motivation:

Wherever an action is asked for in the view, effects or subscriptions, you can provide an action bound to a payload or payload filter by `[someaction, payload]`. It is elegant if the action _in_ the tuple can itself be substituted with a tuple for further processing of the payload.

But when do you _need_ this? Why not just combine the payload filters all at once? It comes up when you want to compose views from intentionally generic and reusable components.

Lets say you have some fancy widget for adjusting a value:

```jsx
const SetFoo = (state, foo) => ({...state, foo})
...
const FooSliderStrip = ({state}) => (
  <div class="slider-strip" ontouchstart={[
    SetFoo,
    event => event.touches[0].clientX
  ]}>/* something with state.foo */</div>
```

You like it so much you want to use it for all your adjustable things in your app, so you turn it into a generic and reusable widget. Now, you can't assume the action is `SetFoo` anymore. You need to take the action as a prop.

```jsx
const SliderStrip = props => (
  <div class="slider-strip" ontouchstart={[
    props.onSet,
    event => event.touches[0].clientX
  ]} > /* something with props.value */ </div>

const FooSliderStrip = ({state}) => <SliderStrip onSet={SetFoo} value={state.foo} />
```

Now besides foo, you want to use the slider to adjust the `.red`, `.green`, and `.blue` values in the `.color` object in the state. Rather than making identical actions `SetColorRed`, `SetColorBlue` et c, you just make one that takes the name as a parameter. 

```js
const SetColorDim = (state, {name, value}) => ({...state, color: {...state.color, [name]: value}})
```

So naturally, you make your color picker like this:

```
const ColorPicker = ({state}} => (
  <div class="color-picker">
    <SliderStrip onSet={[SetColorDim, value=> ({name: 'red', value})]} value={state.color.red} />
    <SliderStrip onSet={[SetColorDim, value=> ({name: 'blue', value})]} value={state.color.blue} />
    <SliderStrip onSet={[SetColorDim, value=> ({name: 'green', value})]} value={state.color.green} />
 </div>
)
```

Very natural and straightforward. Except it won't work, because the Sliders will be trying to dispatch actions like this:
`[[SetColorDim, value => ({name: 'red', value})], event => event.touches[0].clientX]`

which breaks today.

With this fix, the behavior will be the expected, namely to dispatch an action with composed payload: 

`(SetColorDim, {name: 'red', value: event.touches[0].clientX})`