### PR TITLE
Add new fx and sub to handle dispatchEvent and `CustomEvent`s

### DIFF
--- a/lib/events/src/index.js
+++ b/lib/events/src/index.js
@@ -35,6 +35,10 @@ export var createOnCustomEvent = function(eventName) {
   return rawEvent(eventName)
 }
 
+export var eventDetail = function(event) {
+  return event.detail
+}
+
 // AnimationFrame
 export var onAnimationFrame = (function(fx) {
   return function(action) {

--- a/lib/events/src/index.js
+++ b/lib/events/src/index.js
@@ -1,5 +1,11 @@
 var throttledEvent = function(name) {}
 
+var fx = function(a) {
+  return function(b) {
+    return [a, b]
+  }
+}
+
 var rawEvent = function(name) {
   return (function(fx) {
     return function(action) {
@@ -14,6 +20,19 @@ var rawEvent = function(name) {
       removeEventListener(name, listener)
     }
   })
+}
+
+// CustomEvents
+export var dispatchCustomEvent = fx(function(_, props) {
+  dispatchEvent(
+    new CustomEvent(props.name, {
+      detail: props
+    })
+  )
+})
+
+export var createOnCustomEvent = function(eventName) {
+  return rawEvent(eventName)
 }
 
 // AnimationFrame


### PR DESCRIPTION
Say you want to handle some arbitrary event source _"foobar"_. With this you can use `createOnCustomEvent` to create a custom subscription to do just that:

```js
const onFooBar = createOnCustomEvent("foobar")
```

And then use it like you'd use any other _on-event_ subscription such as `onMouseDown`, etc. The subscription delivers you the [`CustomEvent`](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent) object (not its [`detail`](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/detail) as you might naively expect). To grab that, use the `eventDetail` payload filter (also included with this PR free of charge!).

```js
import { createOnCustomEvent, eventDetail } from "@hyperapp/events"

const onFooBar = createOnCustomEvent("foobar")

app({
  ...,
  subscriptions: state => onFooBar([MyAction, eventDetail])
})
```

Finally, there's also an effect to wrap `dispatchEvent`.

```js
import { dispatchCustomEvent } from "@hyperapp/events"

const ClickMeButton = h(
  "button",
  { onClick: dispatchCustomEvent({ name: "foobar", message: "Yo!" }) },
  "Click me!"
)
```

The name is rather long, so I'm open to changing it. The props API mixes `name` with the event props, but that's just an implementation detail. 😏 


