### PR TITLE
More realistic, less cute README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,35 @@ Here's the first example to get you started: a counter that can go up or down. Y
     <script type="module">
       import { h, app } from "https://unpkg.com/hyperapp"
 
+      const cloneObject = (obj) => JSON.parse(JSON.stringify(obj))
+
+      const decrement = function (state) {
+        return function () {
+          const newState = cloneObject(state)
+          newState.counter -= 1
+          return newState
+        }
+      }
+
+      const increment = function (state) {
+        return function () {
+          const newState = cloneObject(state)
+          newState.counter += 1
+          return newState
+        }
+      }
+
       app({
-        init: 0,
-        view: state =>
-          h("main", {}, [
-            h("h1", {}, state),
-            h("button", { onClick: state => state - 1 }, "-"),
-            h("button", { onClick: state => state + 1 }, "+")
-          ]),
+        init: {
+          counter: 0
+        },
+        view: function (state) {
+          return h("main", {}, [
+            h("h1", {}, state.counter),
+            h("button", { onClick: decrement(state) }, "-"),
+            h("button", { onClick: increment(state) }, "+")
+          ])
+        },
         node: document.getElementById("app")
       })
     </script>

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ Here's the first example to get you started: a counter that can go up or down. Y
     <script type="module">
       import { h, app } from "https://unpkg.com/hyperapp"
 
-      const cloneObject = (obj) => JSON.parse(JSON.stringify(obj))
+      const cloneObject = function (obj) {
+        return JSON.parse(JSON.stringify(obj))
+      }
 
       const decrement = function (state) {
         return function () {

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Here's the first example to get you started: a counter that can go up or down. Y
         },
         view: function (state) {
           return h("main", {}, [
-            h("h1", {}, state.counter),
+            h("h1", {}, `Value: ${state.counter}`),
             h("button", { onClick: decrement(state) }, "-"),
             h("button", { onClick: increment(state) }, "+")
           ])


### PR DESCRIPTION
Showing this wonderful framework/piece of software (seriously, I mean it, I reference it all of the time) to somebody without intermediate/deep JavaScript knowledge is confusing because all of the trickery/cleverness that goes on in the example.

I know we've discussed this before, but just today I went to show this software to a Scala developer looking to get more interested in frontend development through JavaScript and was reminded how complicated/subtle the README example is.

I know you didn't like it before, but I'd really ask you reconsider having a more "real world, common" example showcase your fine work.