### PR TITLE
adding back support for oncreate

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -111,7 +111,11 @@ var patchProperty = function(node, key, oldValue, newValue, listener, isSvg) {
     ) {
       node.removeEventListener(key, listener)
     } else if (!oldValue) {
-      node.addEventListener(key, listener)
+      if (key === "create") {
+        newValue.apply(node, [node])
+      } else {
+        node.addEventListener(key, listener)
+      }
     }
   } else if (!isSvg && key !== "list" && key in node) {
     node[key] = newValue == null ? "" : newValue


### PR DESCRIPTION
Upgrading 1.2.10 broke the oncreate event. 

We used to be able to do this:

```
h("div", {
  oncreate: el => {
    console.log(el, "element created");
  }
}, "Test");
```

This PR adds it back. 