### PR TITLE
Lazy view fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -363,10 +363,8 @@ var getTextVNode = function(node) {
 
 var getVNode = function(newVNode, oldVNode) {
   return newVNode.type === LAZY_NODE
-    ? ((!oldVNode ||
-        (!oldVNode.lazy ||
-          propsChanged(oldVNode.lazy, newVNode.lazy))) &&
-        ((oldVNode = getTextVNode(newVNode.lazy.view(newVNode.lazy))).lazy =
+    ? ((!oldVNode || !oldVNode.lazy || propsChanged(oldVNode.lazy, newVNode.lazy))
+        && ((oldVNode = getTextVNode(newVNode.lazy.view(newVNode.lazy))).lazy =
           newVNode.lazy),
       oldVNode)
     : newVNode

--- a/src/index.js
+++ b/src/index.js
@@ -364,7 +364,7 @@ var getTextVNode = function(node) {
 var getVNode = function(newVNode, oldVNode) {
   return newVNode.type === LAZY_NODE
     ? ((!oldVNode ||
-        (oldVNode.type !== LAZY_NODE ||
+        (!oldVNode.lazy ||
           propsChanged(oldVNode.lazy, newVNode.lazy))) &&
         ((oldVNode = getTextVNode(newVNode.lazy.view(newVNode.lazy))).lazy =
           newVNode.lazy),


### PR DESCRIPTION
https://github.com/jorgebucaran/hyperapp/issues/905
Since `oldVNode` is the only result of lazy view and not the lazy node itself, `oldVNode.type !== LAZY_NODE` check leads to constant lazy view re-rendering. Changing check to '!oldVNode.lazy'