### PR TITLE
Fix link from tutorial to api reference

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -897,7 +897,7 @@ will start when we check the auto update box, and stop when it is unchecked.
 ![auto updating](./tut8.png)
 
 > As with effects, Hyperapp offers subscriptions for the most common cases, but you
-> may need to implement your own. Refer to the [API reference](). Again, 
+> may need to implement your own. Refer to the [API reference](./ref.md). Again, 
 > it is no big deal - just not in scope for this tutorial.
 
 If you'd like to see a working example of the final code, have a look [here](https://codesandbox.io/s/hyperapp-tutorial-step-4-8u9q8)


### PR DESCRIPTION
Can see that the API reference is in progress, so might be intentionally busted. Feel free to close, if so.