### PR TITLE
Adds CNAME to site

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+hyperapp.dev


### PR DESCRIPTION
SInce CNAME is [excluded at docs action deployment step](https://github.com/jorgebucaran/hyperapp/pull/909#issuecomment-579709033), 
CNAME should be added manually