### PR TITLE
Use for of instead of forEach

### DIFF
--- a/docs/src/utils.js
+++ b/docs/src/utils.js
@@ -5,9 +5,9 @@ export const entries = (params) => {
 
   const obj = {}
 
-  params.forEach(([key, val]) => {
+  for (const [key, val] of params) {
     obj[key] = val
-  })
+  }
 
   return obj
 }


### PR DESCRIPTION
Fix rendering bug in Edge.

Apparently the params object was an Iterator in edge, but not an array? Not sure why, but this works!

Tested with Microsoft Edge 44