### PR TITLE
only use entries if we are in a modern browser.

### DIFF
--- a/docs/src/utils.js
+++ b/docs/src/utils.js
@@ -1,11 +1,11 @@
 export const entries = (params) => {
   if (typeof Object.fromEntries === 'function') {
-    return Object.fromEntries(params)
+    return Object.fromEntries(params.entries())
   }
 
   const obj = {}
 
-  params.forEach(([key, val]) => {
+  params.forEach((val, key) => {
     obj[key] = val
   })
 
@@ -23,6 +23,6 @@ export const getPathInfo = (path) => {
   return {
     path: withoutTrailingSlash,
     query: search,
-    queryParams: entries(searchParams.entries())
+    queryParams: entries(searchParams)
   }
 }


### PR DESCRIPTION
i used searchParams.entries() in the entries function call.

this made the argument passed to entries an iterator.

fixed this by only using the entries when we need them because Object.fromEntries exists.

fixes: #919, makes #931 obsolete.

btw, this time i downloaded firefox 60 and actually tested it. 