### PR TITLE
[website] Fix issue with weird touch target on the logo in mobile

### DIFF
--- a/docs/src/components/Header/style.css
+++ b/docs/src/components/Header/style.css
@@ -17,6 +17,7 @@
   z-index: 15;
   display: flex;
   align-items: center;
+  width: 100%;
 }
 .logo .v2.mobile {
   height: 2rem;


### PR DESCRIPTION
Currently, to return to homepage in mobile, you need to hit the icon on the left side, because if you hit the right side of the icon, the easter egg switches it to the smaller icon, which moves the target away from the touch and the click event never fires.

This `width: 100%` ensures a large hit target no matter which icon is shown.