### PR TITLE
Read-only form attribute fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ var patchProperty = function(node, key, oldValue, newValue, listener, isSvg) {
     } else if (!oldValue) {
       node.addEventListener(key, listener)
     }
-  } else if (!isSvg && key !== "list" && key in node) {
+  } else if (!isSvg && key !== "list" && key !== "form" && key in node) {
     node[key] = newValue == null ? "" : newValue
   } else if (
     newValue == null ||


### PR DESCRIPTION
HTMLButtonElement.form and HTMLInputElement.form are read-only but can be set using setAttribute. 

Example of a failing case:
```html
<!DOCTYPE html>
<html lang="en">
<head>
    <script type="module">
        import {h, app} from "https://unpkg.com/hyperapp?module"

        app({
            init: 0,
            view: state =>
                h("button", {form: "failing"}, "irrelevant"),
            node: document.getElementById("app")
        })
    </script>
</head>
<body>
<main id="app"></main>
</body>
</html>
```

I found a similar solution in preact: https://github.com/preactjs/preact/blob/master/src/diff/props.js#L113