### PR TITLE
Fix cannot read property X of null/undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -361,7 +361,7 @@ export var memo = (tag, memo) => ({ tag, memo })
 export var text = (value, node) =>
   createVNode(value, EMPTY_OBJ, EMPTY_ARR, node, null, TEXT_NODE)
 
-export var h = (type, props, ...children) =>
+export var h = (type, props, children) =>
   createVNode(
     type,
     props,

--- a/index.js
+++ b/index.js
@@ -361,13 +361,13 @@ export var memo = (tag, memo) => ({ tag, memo })
 export var text = (value, node) =>
   createVNode(value, EMPTY_OBJ, EMPTY_ARR, node, null, TEXT_NODE)
 
-export var h = (type, props, children) =>
+export var h = (type, props, ...children) =>
   createVNode(
     type,
     props,
     isArray(children) ? children : children == null ? EMPTY_ARR : [children],
     null,
-    props.key
+    (props || EMPTY_OBJ).key
   )
 
 export var app = (props) => {


### PR DESCRIPTION
Fixes #983

Add missing spread operator on children, when using `jsx`.

Fix `Cannot read property 'key' of null` when using a `jsx` with a node that does not have any attributes.