### PR TITLE
Fixes subscriptions restart

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,9 @@ var createClass = (obj) => {
 
 var shouldRestart = (a, b) => {
   for (var k in { ...a, ...b }) {
-    if ([].concat(a[k])[0] !== [].concat(b[k])[0]) return true
+    if (typeof (isArray(a[k]) ? a[k][0] : a[k]) === "function") {
+      b[k] = a[k]
+    } else if (a[k] !== b[k]) return true
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -34,8 +34,7 @@ var createClass = (obj) => {
 
 var shouldRestart = (a, b) => {
   for (var k in { ...a, ...b }) {
-    if (typeof (isArray((b[k] = a[k])) ? b[k][0] : b[k]) === "function") {
-    } else if (a[k] !== b[k]) return true
+    if ([].concat(a[k])[0] !== [].concat(b[k])[0]) return true
   }
 }
 


### PR DESCRIPTION
Subscriptions props comparing ('shouldRestart' func): 
since `isArray((b[k] = a[k]))` is an assignment, next condition check `if (a[k] !== b[k]) return true` never happens, which brakes subscription restart (actually never restarts). Fixed.