### PR TITLE
Cleanup old sub before starting new sub on restart

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,8 +57,7 @@ var patchSubs = (oldSubs, newSubs, dispatch) => {
           ? [
               newSub[0],
               newSub[1],
-              newSub[0](dispatch, newSub[1]),
-              oldSub && oldSub[2](),
+              (oldSub && oldSub[2](), newSub[0](dispatch, newSub[1]))
             ]
           : oldSub
         : oldSub && oldSub[2]()


### PR DESCRIPTION
This reverses the order of execution for `newSub[0](dispatch, newSub[1])` and `oldSub && oldSub[2]()` while still storing the results of the former in the sub array for later cleanup execution.

Closes #944.