### PR TITLE
Remove event listener during onUrlRequest unsubscibe

### DIFF
--- a/packages/navigation/index.js
+++ b/packages/navigation/index.js
@@ -39,6 +39,6 @@ export const onUrlRequest = fx(
       }
     }
     addEventListener("click", clicks)
-    return () => addEventListener("click", clicks)
+    return () => removeEventListener("click", clicks)
   }
 )


### PR DESCRIPTION
Adding twice seems like a no-op so it's not obviously broken, but add and remove feels like the intention?