### PR TITLE
Search up the tree to find which A was clicked on

### DIFF
--- a/packages/navigation/index.js
+++ b/packages/navigation/index.js
@@ -27,14 +27,16 @@ export const onUrlRequest = fx(
   ([action]) => ({ action }),
   (dispatch, { action }) => {
     const clicks = (event) => {
+      let target = event.target;
+      while (target && !target.matches("a")) target = target.parentElement;
       if (
         !event.ctrlKey &&
         !event.metaKey &&
         !event.shiftKey &&
-        event.target.matches("a")
+        target
       ) {
         event.preventDefault()
-        const href = event.target.getAttribute("href")
+        const href = target.getAttribute("href")
         dispatch(action, { pathname: href })
       }
     }


### PR DESCRIPTION
Given the code `<a href="/blah"><span>foo</span></a>`, the original onclick handler would see `event.target = <span>`, and then `href = undefined`. With this change, we iterate up from the `<span>` to the `<a>` and then get the `href` from there.