### PR TITLE
Consistent use of Location object

### DIFF
--- a/packages/navigation/index.js
+++ b/packages/navigation/index.js
@@ -11,7 +11,7 @@ export const pushUrl = fx(
 export const onUrlChange = fx(
   ([action]) => ({ action }),
   (dispatch, { action }) => {
-    const popstate = (_) => dispatch(action, location.href)
+    const popstate = (_) => dispatch(action, location)
 
     addEventListener("popstate", popstate)
     addEventListener("hyperapp-pushstate", popstate)


### PR DESCRIPTION
I'm not sure how this worked for the example at https://codesandbox.io/s/hyperapp-minimal-navigation-example-2-g0mr7 - when I tried it with my real app, I had issues because sometimes `state.location` was a `Location` object and sometimes it was a `string`. When it's consistently a `Location`, everything seems to work :)