### PR TITLE
Return dispatch

### DIFF
--- a/index.js
+++ b/index.js
@@ -354,7 +354,7 @@ var createVNode = (tag, props, children, type, node) => ({
   key: props.key,
   children,
   type,
-  node,
+  node
 })
 
 export var memo = (tag, memo) => ({ tag, memo })
@@ -396,6 +396,8 @@ export var app = (props) => {
               (fx) => fx && fx !== true && fx[0](dispatch, fx[1]),
               setState(action[0])
             )
+      : action == null
+      ? patchSubs(subs, EMPTY_ARR, (dispatch = id))
       : setState(action)
   )
 
@@ -413,5 +415,5 @@ export var app = (props) => {
       (doing = false)
     ))
 
-  dispatch(props.init)
+  return dispatch(props.init), dispatch
 }


### PR DESCRIPTION
This PR does two things:
- It makes `app()` return the internal `dispatch` so it could be used by external utilities, for e g dev tooling
- It makes it so if you ever dispatch with no arguments (wether with the returned function, or in an effect, or return void from an action) it will _stop_ the app

Stopping an app means:
- future calls to dispatch do nothing.
- all possible active subscriptions are stopped
- the DOM is _not_ touched. It remains exactly as it was before the app was stopped.