### PR TITLE
Explain the conditions which cause a subscription to be restarted

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -377,6 +377,8 @@ They are used for both adding and removing connections to events outside hyperap
 
 Binds **dispatch** to an external event. Returns a cleanup function that removes the binding.
 
+The subscription function (`keySub` in this case) will be called when it first appears in the `subscriptions:` list, and the anonymous cleanup function will be called when it no longer appears in the list. Also, when the `props` object changes, the old cleanup function will be called and the subscription function will be called a second time with the new `props`, creating a new subscription. Note that the "should this subscription be restarted with new settings?" function uses the JavaScript idea of equality - if your `props` contains an `array` or an `object`, then it needs to be _the same array_, not just _an array which contains the same values_, otherwise the subscription will get destroyed and recreated every time!
+
 ```js
 const keySub = (dispatch, props) => {
   // Hook up dispatch to external events


### PR DESCRIPTION
I spent a long time being very confused about subscriptions, because sometimes they would hang around and sometimes they would get restarted on every state change - now I think I understand how they work, so adding some documentation for the next person to be in my situation :)

~

(Incidentally, even the example subscription suffers from the constant re-subscribing; one needs to extract `["w", "a", "s", "d"]` into a module-level constant to avoid it. Not such a big deal for a keyboard listener where we're only wasting a few nanoseconds of CPU time with frequent addEventListener / removeEventListener - but more of a pain for network stuff. Which makes me think it would be nice if `shouldRestart` was more forgiving, but that's a big discussion for a different time :) )