### PR TITLE
Dispatching action as null destroys the state.

### DIFF
--- a/index.js
+++ b/index.js
@@ -412,7 +412,7 @@ export var app = ({
                 (fx) => fx && fx !== true && fx[0](dispatch, fx[1]),
                 update(action[0])
               )
-        : update(action)
+        : update(action || state)
     ))(init),
     dispatch
   )


### PR DESCRIPTION
When action is `null`, it tries to `update(action)`, destroying the state.
We can pass the current `state` to the update function, so it works as a no-op.