### PR TITLE
Only use pushState for same-origin URLs

### DIFF
--- a/packages/navigation/index.js
+++ b/packages/navigation/index.js
@@ -35,9 +35,12 @@ export const onUrlRequest = fx(
         !event.shiftKey &&
         target
       ) {
-        event.preventDefault()
         const href = target.getAttribute("href")
-        dispatch(action, { pathname: href })
+        const dest = new URL(href, location.href);
+        if (dest.protocol == location.protocol && dest.hostname == location.hostname) {
+          event.preventDefault()
+          dispatch(action, { pathname: href })  
+        }
       }
     }
     addEventListener("click", clicks)


### PR DESCRIPTION
Now links within the app will be handled by local JS, but links to external sites will be handled by the browser

Fixes #1033

Test plan: Running on https://scuba.shish.io/ - links within the app work (instantly switching screens), links on the "about" page also work (taking the user to a different website)