### PR TITLE
Use node.remove() instead of parent.removeChild(node)

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ var patch = (parent, node, oldVNode, newVNode, listener, isSvg) => {
       node
     )
     if (oldVNode != null) {
-      parent.removeChild(oldVNode.node)
+      oldVNode.node.remove()
     }
   } else {
     var tmpVKid
@@ -227,7 +227,7 @@ var patch = (parent, node, oldVNode, newVNode, listener, isSvg) => {
       }
     } else if (newHead > newTail) {
       while (oldHead <= oldTail) {
-        node.removeChild(oldVKids[oldHead++].node)
+        oldVKids[oldHead++].node.remove()
       }
     } else {
       for (var keyed = {}, newKeyed = {}, i = oldHead; i <= oldTail; i++) {
@@ -247,7 +247,7 @@ var patch = (parent, node, oldVNode, newVNode, listener, isSvg) => {
           (newKey != null && newKey === getKey(oldVKids[oldHead + 1]))
         ) {
           if (oldKey == null) {
-            node.removeChild(oldVKid.node)
+            oldVKid.node.remove()
           }
           oldHead++
           continue
@@ -306,13 +306,13 @@ var patch = (parent, node, oldVNode, newVNode, listener, isSvg) => {
 
       while (oldHead <= oldTail) {
         if (getKey((oldVKid = oldVKids[oldHead++])) == null) {
-          node.removeChild(oldVKid.node)
+          oldVKid.node.remove()
         }
       }
 
       for (var i in keyed) {
         if (newKeyed[i] == null) {
-          node.removeChild(keyed[i].node)
+          keyed[i].node.remove()
         }
       }
     }


### PR DESCRIPTION
Hi Jorge,

not sure if you still want to support olden and not-at-all-golden Internet Explorer. If you're ditching it, then we could as well inch ourselves closer to more modern JS. 

Here I am suggesting replacing the pattern `parent.removeChild(node)` with the simpler `node.remove()`. According to [](https://caniuse.com/childnode-remove) it is safe to assume that by now this method is supported by all non-IE-browsers out there. 

Benefit: We can shave off a few more bytes.

Regards,
Sven