### PR TITLE
Use node.append(child) instead of node.appendChild(child)

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ var createNode = (vdom, listener, isSvg) => {
   }
 
   for (var i = 0; i < vdom.children.length; i++) {
-    node.appendChild(
+    node.append(
       createNode(
         (vdom.children[i] = maybeVNode(vdom.children[i])),
         listener,


### PR DESCRIPTION
Hi Jorge,

similar to [PR 1036](https://github.com/jorgebucaran/hyperapp/pull/1036) I suggest replacing node.appendChild(child) with node.append(child). Difference explained here: https://dev.to/ibn_abubakre/append-vs-appendchild-a4m.

Benefit: 5 characters/bytes of code less.

Regards,
Sven 