### PR TITLE
Types: enable definite payloads

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -74,7 +74,7 @@ declare module "hyperapp" {
   type Action<S, P = any> = ActionTransform<S, P> | ActionWithPayload<S, P>
   type ActionTransform<S, P = any> = (
     state: State<S>,
-    payload?: Payload<P>
+    payload: Payload<P>
   ) => State<S> | StateWithEffects<S> | Action<S>
   type ActionWithPayload<S, P> = [ActionTransform<S, P>, Payload<P>]
 


### PR DESCRIPTION
The current types require my actions to handle the eventuality that the payload might be undefined. Even when that can't happen. For example the following example is perfectly valid and would run just fine:

```ts
import { h, text, app } from "hyperapp"

type State = { inputText: string }

const HandleInput = (state: State, event: Event) => ({
    ...state,
    inputText: (event.target as HTMLInputElement).value,
})

let node = document.getElementById("app")
node &&
    app({
        node,
        init: { inputText: "" },
        view: state =>
            h("main", {}, [
                h("input", {
                    type: "text",
                    value: state.inputText,
                    oninput: HandleInput,
                }),
            ]),
    })

```

but typescript complains about it:

<img width="638" alt="Screenshot 2021-04-05 at 20 15 35" src="https://user-images.githubusercontent.com/2061445/113611359-b26c7580-964e-11eb-8fba-b3f984237e8c.png">

This pull request changes it so that there is no error.