### PR TITLE
Update Types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -102,12 +102,15 @@ declare module "hyperapp" {
   ) => void
 
   // A dispatchable entity, when processed, causes a state transition.
-  type Dispatchable<S> = S | StateWithEffects<S> | Reaction<S>
+  type Dispatchable<S, P = any> =
+    | S
+    | StateWithEffects<S>
+    | Action<S, P>
+    | ActionWithPayload<S, P>
 
   // An action transforms existing state and/or wraps another action.
-  type Reaction<S, P = any> = Action<S, P> | ActionWithPayload<S, P>
   type Action<S, P = any> = (state: S, payload: P) => Dispatchable<S>
-  type ActionWithPayload<S, P> = [action: Action<S, P>, payload: P]
+  type ActionWithPayload<S, P = any> = [action: Action<S, P>, payload: P]
 
   // A transform carries out the transition from one state to another.
   type Transform<S, P = any> = (
@@ -138,7 +141,7 @@ declare module "hyperapp" {
     readonly tag: Tag<S>
     readonly key: Key
     memo?: PropList<S, C>
-    events?: Record<string, Reaction<S>>
+    events?: Record<string, Action<S> | ActionWithPayload<S>>
 
     // `_VDOM` is a guard property which gives us a way to tell `VDOM` objects
     // apart from `PropList` objects. Since we don't expect users to manually
@@ -167,8 +170,9 @@ declare module "hyperapp" {
 
   // Virtual DOM properties will often correspond to HTML attributes.
   type PropList<S, C> = Readonly<
-    ElementCreationOptions &
-    EventActions<S, C> & {
+    | ElementCreationOptions
+    & EventActions<S, C>
+    & {
       [_: string]: unknown
       class?: ClassProp
       key?: Key
@@ -203,12 +207,15 @@ declare module "hyperapp" {
 
   // Event handlers are implemented using actions.
   type EventActions<S, C> = {
-    [K in keyof EventsMap]?: Reaction<S, EventsMap[K]> | ActionWithPayload<S, C>
+    [K in keyof EventsMap]?:
+      | Action<S, EventsMap[K]>
+      | ActionWithPayload<S, EventsMap[K]>
+      | ActionWithPayload<S, C>
   }
 
   // Most event typings are provided by TypeScript itself.
-  type EventsMap
-    = { [K in keyof HTMLElementEventMap as `on${K}`]: HTMLElementEventMap[K] }
+  type EventsMap =
+    | { [K in keyof HTMLElementEventMap as `on${K}`]: HTMLElementEventMap[K] }
     & { [K in keyof WindowEventMap as `on${K}`]: WindowEventMap[K] }
     & { onsearch: Event }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -166,7 +166,12 @@ declare module "hyperapp" {
 
   // Virtual DOM properties will often correspond to HTML attributes.
   type PropList<S> = Readonly<
-    | ElementCreationOptions
+    | Partial<Omit<HTMLElement, keyof (
+      | DocumentAndElementEventHandlers
+      & ElementCSSInlineStyle
+      & GlobalEventHandlers
+    )>>
+    & ElementCreationOptions
     & EventActions<S>
     & {
       [_: string]: unknown

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,7 @@ declare module "hyperapp" {
   ): VDOM<S>
 
   // `text()` creates a virtual DOM node representing plain text.
-  function text<T, S>(
+  function text<S, T = unknown>(
     // While most values can be stringified, symbols and functions cannot.
     value: T extends symbol | ((..._: any[]) => any) ? never : T,
     node?: Node

--- a/index.d.ts
+++ b/index.d.ts
@@ -96,7 +96,10 @@ declare module "hyperapp" {
   // ---------------------------------------------------------------------------
 
   // A dispatched action handles an event in the context of the current state.
-  type Dispatch<S> = (action: Action<S>, payload?: any) => void
+  type Dispatch<S> = (
+    dispatchable: Dispatchable<S>,
+    payload?: any
+  ) => void
 
   // A dispatchable entity, when processed, causes a state transition.
   type Dispatchable<S> = S | StateWithEffects<S> | Action<S>

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,7 @@ declare module "hyperapp" {
 
   // This utility type requires every property of an object or none at all.
   // `App` uses this to make sure `view:` always appears alongside `node:`.
-  type Bundle<T> = T | { [K in keyof T]?: never }
+  type AllOrNothing<T> = T | { [K in keyof T]?: never }
 
   // ---------------------------------------------------------------------------
 
@@ -52,7 +52,7 @@ declare module "hyperapp" {
       subscriptions: Subscriptions<S>
       dispatch: DispatchInitializer<S>
     }> &
-    Bundle<{
+    AllOrNothing<{
       view: View<S>
       node: Node
     }>

--- a/index.d.ts
+++ b/index.d.ts
@@ -112,12 +112,6 @@ declare module "hyperapp" {
   type Action<S, P = any> = (state: S, payload: P) => Dispatchable<S>
   type ActionWithPayload<S, P = any> = [action: Action<S, P>, payload: P]
 
-  // A transform carries out the transition from one state to another.
-  type Transform<S, P = any> = (
-    state: S | StateWithEffects<S>,
-    payload: P
-  ) => S | StateWithEffects<S>
-
   // State can be associated with a list of effects to run.
   type StateWithEffects<S, P = any> = [state: S, ...effects: Effect<S, P>[]]
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -102,12 +102,12 @@ declare module "hyperapp" {
   ) => void
 
   // A dispatchable entity, when processed, causes a state transition.
-  type Dispatchable<S> = S | StateWithEffects<S> | Action<S>
+  type Dispatchable<S> = S | StateWithEffects<S> | Reaction<S>
 
   // An action transforms existing state and/or wraps another action.
-  type Action<S, P = any> = ActionTransform<S, P> | ActionWithPayload<S, P>
-  type ActionTransform<S, P = any> = (state: S, payload: P) => Dispatchable<S>
-  type ActionWithPayload<S, P> = [action: ActionTransform<S, P>, payload: P]
+  type Reaction<S, P = any> = Action<S, P> | ActionWithPayload<S, P>
+  type Action<S, P = any> = (state: S, payload: P) => Dispatchable<S>
+  type ActionWithPayload<S, P> = [action: Action<S, P>, payload: P]
 
   // A transform carries out the transition from one state to another.
   type Transform<S, P = any> = (
@@ -138,7 +138,7 @@ declare module "hyperapp" {
     readonly tag: Tag<S>
     readonly key: Key
     memo?: PropList<S, C>
-    events?: Record<string, Action<S>>
+    events?: Record<string, Reaction<S>>
 
     // `_VDOM` is a guard property which gives us a way to tell `VDOM` objects
     // apart from `PropList` objects. Since we don't expect users to manually
@@ -203,7 +203,7 @@ declare module "hyperapp" {
 
   // Event handlers are implemented using actions.
   type EventActions<S, C> = {
-    [K in keyof EventsMap]?: Action<S, EventsMap[K]> | ActionWithPayload<S, C>
+    [K in keyof EventsMap]?: Reaction<S, EventsMap[K]> | ActionWithPayload<S, C>
   }
 
   // Most event typings are provided by TypeScript itself.

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,10 @@ declare module "hyperapp" {
   type AtLeastOne<T> = { [K in keyof T]: Pick<T, K> }[keyof T]
   // Credit: https://stackoverflow.com/a/59987826/1935675
 
+  // This utility type requires every property of an object or none at all.
+  // `App` uses this to make sure `view:` always appears alongside `node:`.
+  type Bundle<T> = T | { [K in keyof T]?: never }
+
   // ---------------------------------------------------------------------------
 
   // A Hyperapp instance generally has an initial state and a base view and is
@@ -47,15 +51,11 @@ declare module "hyperapp" {
       init: State<S> | StateWithEffects<S> | Action<S>
       subscriptions: Subscriptions<S>
       dispatch: DispatchInitializer<S>
-    }> & (
-      {
-        view: View<S>
-        node: Node
-      } | {
-        view?: never
-        node?: never
-      }
-    )
+    }> &
+    Bundle<{
+      view: View<S>
+      node: Node
+    }>
   >
 
   // A view builds a virtual DOM node representation of the application state.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "files": [
     "*.[tj]s"
   ],
-  "types": "./index.d.ts",
   "keywords": [
     "framework",
     "hyperapp",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "files": [
     "*.[tj]s"
   ],
+  "types": "./index.d.ts",
   "keywords": [
     "framework",
     "hyperapp",


### PR DESCRIPTION
This PR was originally about `App<S>` but has evolved into a pervasive update.

Changelog:

- Added `TypedH<S>`. It lets you define a version of `h` that has your app's state type "baked in" so you don't need to worry about whether or not you need to explicitly assign the generic type parameter for `h` every time you call it.
  - Originally from: https://github.com/jorgebucaran/hyperapp/pull/1049
  - Addresses: https://github.com/jorgebucaran/hyperapp/issues/1048-
- Added the utility types `AllOrNothing<T>`, `AtLeastOne<T>`, and `IndexableByKey`. They assist the implementation of some of the other types which are refactored accordingly.
  - These utility types might be useful to the user in their own right.
- Improved `App<S>` to validate all combinations of `app()` props usage.
- Improved validation of using event actions with custom payloads.
  - For instance, this should be treated correctly now: `h("p", { onclick: [MyAction, 42] }, text("hi"))`.
- Made the `payload` parameter of `Effecter<S, P>` and `Subscriber<S, P>` definite.
  - This follows from discoveries found during discussions of: https://github.com/jorgebucaran/hyperapp/pull/1045
- Removed `EffectCreator<S, D>`. I don't believe it adds enough value even on a purely self-documenting code basis.
- Removed `Payload<P>` because in the places where it could appear either a parameter name or named tuple could express the same level of detail.
- Removed `State<S>` for partially the same reason as removing `Payload<P>`. Another reason was I wanted to prevent potential confusion on the user's end about whether `State<S>` is required like how `StateWithEffects<S>` is.
- Added `Dispatchable<S>`. It simplifies a couple type definitions while adding more meaning. It can also be handy to the user when defining effecters and subscribers.
  - Based off of @zaceno's [idea for a dispatchable type](https://discord.com/channels/804672552348680192/805746611467583499/829100737967030364).
- Added names to tuple types. This helped with the rationale for removing `Payload<P>` and `State<S>`.
- Added a `types` reference to `index.d.ts` in `package.json` per @talentlessguy's [suggestion](https://discord.com/channels/804672552348680192/805746611467583499/830532470122217472).
- Renamed some generic type parameters.
- Added a little more commentary.

---

Original PR title and text for posterity:

### Improve the `App` type

This fixes certain cases when using `App`. I've also added a little more commentary in some parts of the type definitions.

Here are the relevant lines in the types test suite if you're curious:

- https://github.com/icylace/hyperapp-types-tests/blob/4ebe6e928945184bfb96321d40cfa6a88b058686/test/api/app.test.ts#L26
- https://github.com/icylace/hyperapp-types-tests/blob/4ebe6e928945184bfb96321d40cfa6a88b058686/test/api/app.test.ts#L36-L73
