### PR TITLE
Add the new `TypedH<S>` type.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,17 @@ declare module "hyperapp" {
 
   // ---------------------------------------------------------------------------
 
+  // This lets you use a version of `h` which assumes your particular app state.
+  interface TypedH<S> {
+    <_, T extends string = string>(
+      tag: T extends "" ? never : T,
+      props: PropList<S>,
+      children?: MaybeVDOM<S> | readonly MaybeVDOM<S>[]
+    ): VDOM<S>
+  }
+
+  // ---------------------------------------------------------------------------
+
   // A Hyperapp instance has an initial state and a base view.
   // It's usually mounted over an available DOM element.
   type App<S> =


### PR DESCRIPTION
Introducing the `TypedH<S>` type.  It lets you define a version of `h` that has your app's state type "baked in" so you don't need to worry about whether or not you need to explicitly assign the type variable for `h` every time you call it.

```ts
import { h as ha } from "hyperapp"

type YourAppState = { youGetTheIdea: boolean }

const h: TypedH<YourAppState> = ha

// ... continue using `h` like you normally would.
```

Addresses https://github.com/jorgebucaran/hyperapp/issues/1048.