### PR TITLE
Update Types Some More

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -102,12 +102,15 @@ declare module "hyperapp" {
   ) => void
 
   // A dispatchable entity, when processed, causes a state transition.
-  type Dispatchable<S> = S | StateWithEffects<S> | Reaction<S>
+  type Dispatchable<S, P = any> =
+    | S
+    | StateWithEffects<S>
+    | Action<S, P>
+    | ActionWithPayload<S, P>
 
   // An action transforms existing state and/or wraps another action.
-  type Reaction<S, P = any> = Action<S, P> | ActionWithPayload<S, P>
   type Action<S, P = any> = (state: S, payload: P) => Dispatchable<S>
-  type ActionWithPayload<S, P> = [action: Action<S, P>, payload: P]
+  type ActionWithPayload<S, P = any> = [action: Action<S, P>, payload: P]
 
   // A transform carries out the transition from one state to another.
   type Transform<S, P = any> = (
@@ -138,7 +141,7 @@ declare module "hyperapp" {
     readonly tag: Tag<S>
     readonly key: Key
     memo?: PropList<S, C>
-    events?: Record<string, Reaction<S>>
+    events?: Record<string, Action<S> | ActionWithPayload<S>>
 
     // `_VDOM` is a guard property which gives us a way to tell `VDOM` objects
     // apart from `PropList` objects. Since we don't expect users to manually
@@ -167,8 +170,9 @@ declare module "hyperapp" {
 
   // Virtual DOM properties will often correspond to HTML attributes.
   type PropList<S, C> = Readonly<
-    ElementCreationOptions &
-    EventActions<S, C> & {
+    | ElementCreationOptions
+    & EventActions<S, C>
+    & {
       [_: string]: unknown
       class?: ClassProp
       key?: Key
@@ -203,12 +207,15 @@ declare module "hyperapp" {
 
   // Event handlers are implemented using actions.
   type EventActions<S, C> = {
-    [K in keyof EventsMap]?: Reaction<S, EventsMap[K]> | ActionWithPayload<S, C>
+    [K in keyof EventsMap]?:
+      | Action<S, EventsMap[K]>
+      | ActionWithPayload<S, EventsMap[K]>
+      | ActionWithPayload<S, C>
   }
 
   // Most event typings are provided by TypeScript itself.
-  type EventsMap
-    = { [K in keyof HTMLElementEventMap as `on${K}`]: HTMLElementEventMap[K] }
+  type EventsMap =
+    | { [K in keyof HTMLElementEventMap as `on${K}`]: HTMLElementEventMap[K] }
     & { [K in keyof WindowEventMap as `on${K}`]: WindowEventMap[K] }
     & { onsearch: Event }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -166,7 +166,12 @@ declare module "hyperapp" {
 
   // Virtual DOM properties will often correspond to HTML attributes.
   type PropList<S> = Readonly<
-    | ElementCreationOptions
+    | Partial<Omit<HTMLElement, keyof (
+      | DocumentAndElementEventHandlers
+      & ElementCSSInlineStyle
+      & GlobalEventHandlers
+    )>>
+    & ElementCreationOptions
     & EventActions<S>
     & {
       [_: string]: unknown

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,8 +22,7 @@ declare module "hyperapp" {
   // `text()` creates a virtual DOM node representing plain text.
   function text<S, T = unknown>(
     // While most values can be stringified, symbols and functions cannot.
-    value: T extends symbol | ((..._: any[]) => any) ? never : T,
-    node?: Node
+    value: T extends symbol | ((..._: any[]) => any) ? never : T
   ): VDOM<S>
 
   // ---------------------------------------------------------------------------

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,7 @@ declare module "hyperapp" {
   ): VDOM<S>
 
   // `text()` creates a virtual DOM node representing plain text.
-  function text<T, S>(
+  function text<S, T = unknown>(
     // While most values can be stringified, symbols and functions cannot.
     value: T extends symbol | ((..._: any[]) => any) ? never : T,
     node?: Node

--- a/index.d.ts
+++ b/index.d.ts
@@ -96,7 +96,10 @@ declare module "hyperapp" {
   // ---------------------------------------------------------------------------
 
   // A dispatched action handles an event in the context of the current state.
-  type Dispatch<S> = (action: Action<S>, payload?: any) => void
+  type Dispatch<S> = (
+    dispatchable: Dispatchable<S>,
+    payload?: any
+  ) => void
 
   // A dispatchable entity, when processed, causes a state transition.
   type Dispatchable<S> = S | StateWithEffects<S> | Action<S>

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,13 @@ declare module "hyperapp" {
   ): VDOM<S>
 
   // `memo()` stores a view along with any given data for it.
-  function memo<S, D extends string | any[] | Record<string, any>>(
+  function memo<
+    S,
+    D extends string | unknown[] | Record<string, any> =
+      | string
+      | unknown[]
+      | Record<string, any>
+  >(
     view: View<D>,
     data: D
   ): VDOM<S>

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,7 @@ declare module "hyperapp" {
 
   // This utility type requires every property of an object or none at all.
   // `App` uses this to make sure `view:` always appears alongside `node:`.
-  type Bundle<T> = T | { [K in keyof T]?: never }
+  type AllOrNothing<T> = T | { [K in keyof T]?: never }
 
   // ---------------------------------------------------------------------------
 
@@ -52,7 +52,7 @@ declare module "hyperapp" {
       subscriptions: Subscriptions<S>
       dispatch: DispatchInitializer<S>
     }> &
-    Bundle<{
+    AllOrNothing<{
       view: View<S>
       node: Node
     }>

--- a/index.d.ts
+++ b/index.d.ts
@@ -112,12 +112,6 @@ declare module "hyperapp" {
   type Action<S, P = any> = (state: S, payload: P) => Dispatchable<S>
   type ActionWithPayload<S, P = any> = [action: Action<S, P>, payload: P]
 
-  // A transform carries out the transition from one state to another.
-  type Transform<S, P = any> = (
-    state: S | StateWithEffects<S>,
-    payload: P
-  ) => S | StateWithEffects<S>
-
   // State can be associated with a list of effects to run.
   type StateWithEffects<S, P = any> = [state: S, ...effects: Effect<S, P>[]]
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -102,12 +102,12 @@ declare module "hyperapp" {
   ) => void
 
   // A dispatchable entity, when processed, causes a state transition.
-  type Dispatchable<S> = S | StateWithEffects<S> | Action<S>
+  type Dispatchable<S> = S | StateWithEffects<S> | Reaction<S>
 
   // An action transforms existing state and/or wraps another action.
-  type Action<S, P = any> = ActionTransform<S, P> | ActionWithPayload<S, P>
-  type ActionTransform<S, P = any> = (state: S, payload: P) => Dispatchable<S>
-  type ActionWithPayload<S, P> = [action: ActionTransform<S, P>, payload: P]
+  type Reaction<S, P = any> = Action<S, P> | ActionWithPayload<S, P>
+  type Action<S, P = any> = (state: S, payload: P) => Dispatchable<S>
+  type ActionWithPayload<S, P> = [action: Action<S, P>, payload: P]
 
   // A transform carries out the transition from one state to another.
   type Transform<S, P = any> = (
@@ -138,7 +138,7 @@ declare module "hyperapp" {
     readonly tag: Tag<S>
     readonly key: Key
     memo?: PropList<S, C>
-    events?: Record<string, Action<S>>
+    events?: Record<string, Reaction<S>>
 
     // `_VDOM` is a guard property which gives us a way to tell `VDOM` objects
     // apart from `PropList` objects. Since we don't expect users to manually
@@ -203,7 +203,7 @@ declare module "hyperapp" {
 
   // Event handlers are implemented using actions.
   type EventActions<S, C> = {
-    [K in keyof EventsMap]?: Action<S, EventsMap[K]> | ActionWithPayload<S, C>
+    [K in keyof EventsMap]?: Reaction<S, EventsMap[K]> | ActionWithPayload<S, C>
   }
 
   // Most event typings are provided by TypeScript itself.

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,10 @@ declare module "hyperapp" {
   type AtLeastOne<T> = { [K in keyof T]: Pick<T, K> }[keyof T]
   // Credit: https://stackoverflow.com/a/59987826/1935675
 
+  // This utility type requires every property of an object or none at all.
+  // `App` uses this to make sure `view:` always appears alongside `node:`.
+  type Bundle<T> = T | { [K in keyof T]?: never }
+
   // ---------------------------------------------------------------------------
 
   // A Hyperapp instance generally has an initial state and a base view and is
@@ -47,15 +51,11 @@ declare module "hyperapp" {
       init: State<S> | StateWithEffects<S> | Action<S>
       subscriptions: Subscriptions<S>
       dispatch: DispatchInitializer<S>
-    }> & (
-      {
-        view: View<S>
-        node: Node
-      } | {
-        view?: never
-        node?: never
-      }
-    )
+    }> &
+    Bundle<{
+      view: View<S>
+      node: Node
+    }>
   >
 
   // A view builds a virtual DOM node representation of the application state.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "files": [
     "*.[tj]s"
   ],
-  "types": "./index.d.ts",
   "keywords": [
     "framework",
     "hyperapp",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "files": [
     "*.[tj]s"
   ],
+  "types": "./index.d.ts",
   "keywords": [
     "framework",
     "hyperapp",


### PR DESCRIPTION
Changelog (thus far):

- Removed the `node` parameter from `text()`.
- Improved `memo()` to handle more edge cases.
