### PR TITLE
Fix edge cases for the type definition of `memo()`.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,10 +14,13 @@ declare module "hyperapp" {
   ): VDOM<S>
 
   // `memo()` stores a view along with any given data for it.
-  function memo<S, D extends string | any[] | Record<string, any>>(
-    view: View<D>,
-    data: D
-  ): VDOM<S>
+  function memo<
+    S,
+    D extends string | unknown[] | Record<string, any> =
+      | string
+      | unknown[]
+      | Record<string, any>
+  >(view: View<D>, data: D): VDOM<S>
 
   // `text()` creates a virtual DOM node representing plain text.
   function text<S, T = unknown>(


### PR DESCRIPTION
Improves the type definition for `memo()` so when its state type parameter is set it won't force the user to define the memoized data type parameter if they don't want to.

For instance, the following test case now works:

```ts
// $ExpectType VDOM<number>
memo<number>(text, "hi")
```

For more test cases, see:
https://github.com/icylace/hyperapp-types-tests/blob/master/test/api/memo.test.ts
