### PR TITLE
Optimize Types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -79,7 +79,8 @@ declare module "hyperapp" {
       init: Dispatchable<S>
 
       // The subscriptions function manages a set of subscriptions.
-      subscriptions: (state: S) => (boolean | undefined | Subscription<S>)[]
+      subscriptions: (state: S) =>
+        readonly (boolean | undefined | Subscription<S>)[]
 
       // Dispatching can be augmented to do custom processing.
       dispatch: (dispatch: Dispatch<S>) => Dispatch<S>
@@ -105,7 +106,7 @@ declare module "hyperapp" {
       K extends "style"
       ? StyleProp
       : T[K] extends [action: Action<S, infer P>, payload: unknown]
-      ? [action: Action<S, P>, payload: P]
+      ? readonly [action: Action<S, P>, payload: P]
       : T[K]
   }
 
@@ -117,10 +118,10 @@ declare module "hyperapp" {
     | S
     | [state: S, ...effects: Effect<S, P>[]]
     | Action<S, P>
-    | [action: Action<S, P>, payload: P]
+    | readonly [action: Action<S, P>, payload: P]
 
   // An effect is where side effects and any additional dispatching may occur.
-  type Effect<S, P = unknown> = [
+  type Effect<S, P = unknown> = readonly [
     effecter: (dispatch: Dispatch<S>, payload: P) => void | Promise<void>,
     payload: P
   ]
@@ -129,7 +130,7 @@ declare module "hyperapp" {
   type EventActions<S> = {
     [K in keyof EventsMap]:
       | Action<S, EventsMap[K]>
-      | [action: Action<S>, payload: unknown]
+      | readonly [action: Action<S>, payload: unknown]
   }
 
   // In certain places a virtual DOM node can be made optional.
@@ -170,7 +171,7 @@ declare module "hyperapp" {
   }
 
   // A subscription reacts to external activity.
-  type Subscription<S, P = unknown> = [
+  type Subscription<S, P = unknown> = readonly [
     subscriber: (dispatch: Dispatch<S>, payload: P) => void | Unsubscribe,
     payload: P
   ]
@@ -181,11 +182,15 @@ declare module "hyperapp" {
   // A virtual DOM node (a.k.a. VNode) represents an actual DOM element.
   type VNode<S> = {
     readonly props: Props<S>
-    readonly children: MaybeVNode<S>[]
+    readonly children: readonly MaybeVNode<S>[]
     node: null | undefined | Node
 
     // Hyperapp takes care of using native Web platform event handlers for us.
-    events?: Record<string, Action<S> | [action: Action<S>, payload: unknown]>
+    events?:
+      Record<
+        string,
+        Action<S> | readonly [action: Action<S>, payload: unknown]
+      >
 
     // A key can uniquely associate a VNode with a certain DOM element.
     readonly key: string | null | undefined

--- a/index.d.ts
+++ b/index.d.ts
@@ -172,7 +172,7 @@ declare module "hyperapp" {
 
   // A subscription reacts to external activity.
   type Subscription<S, P = any> = readonly [
-    subscriber: (dispatch: Dispatch<S>, payload: P) => void | Unsubscribe,
+    subscriber: (dispatch: Dispatch<S>, payload: P) => Unsubscribe,
     payload: P
   ]
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,170 +1,142 @@
 // Minimum TypeScript Version: 4.2
 
+// This requires every property of an object or none at all.
+type AllOrNothing<T> = T | { [K in keyof T]?: never }
+
+// This ensures at least one property in an object is present.
+type AtLeastOne<T> = { [K in keyof T]: Pick<T, K> }[keyof T]
+// Credit: https://stackoverflow.com/a/59987826/1935675
+
+// This ensures at least one object property group is present.
+type AtLeastSomething<T, U> = U | AtLeastOne<T> & AllOrNothing<U>
+
+// Most event typings are provided by TypeScript itself.
+type EventsMap =
+  & { [K in keyof HTMLElementEventMap as `on${K}`]: HTMLElementEventMap[K] }
+  & { [K in keyof WindowEventMap as `on${K}`]: WindowEventMap[K] }
+  & { onsearch: Event }
+
+// Indexable values are able to use subscripting.
+type Indexable = string | unknown[] | Record<string, any>
+
+// This validates plain objects while invalidating array objects and string
+// objects by disallowing numerical indexing.
+type IndexableByKey = Record<number, never>
+
+// Empty strings can cause issues in certain places.
+type NonEmptyString<T> = T extends "" ? never : T
+
+// -----------------------------------------------------------------------------
+
 declare module "hyperapp" {
-  // `app()` initiates a Hyperapp instance. `app()` along with runners and
-  // subscribers are the only places where side effects are allowed.
+  // `app()` initiates a Hyperapp instance. Only `app()`'s `node:` property and
+  // effecters and subscribers are allowed to have side effects.
   function app<S>(props: App<S>): Dispatch<S>
 
   // `h()` builds a virtual DOM node.
   function h<S, C = unknown, T extends string = string>(
-    // Tags cannot be empty strings.
-    tag: T extends "" ? never : T,
-    props: ValidateCustomPayloads<S, C> & PropList<S>,
-    children?: MaybeVDOM<S> | readonly MaybeVDOM<S>[]
-  ): VDOM<S>
+    tag: NonEmptyString<T>,
+    props: CustomPayloads<S, C> & Props<S>,
+    children?: MaybeVNode<S> | readonly MaybeVNode<S>[]
+  ): VNode<S>
 
   // `memo()` stores a view along with any given data for it.
-  function memo<
-    S,
-    D extends string | unknown[] | Record<string, any> =
-      | string
-      | unknown[]
-      | Record<string, any>
-  >(view: View<D>, data: D): VDOM<S>
+  function memo<S, D extends Indexable = Indexable>(
+    view: (data: D) => VNode<S>,
+    data: D
+  ): VNode<S>
 
   // `text()` creates a virtual DOM node representing plain text.
   function text<S, T = unknown>(
-    // While most values can be stringified, symbols and functions cannot.
-    value: T extends symbol | ((..._: any[]) => any) ? never : T
-  ): VDOM<S>
+    // Values, aside from symbols and functions, can be handled.
+    value: T extends symbol | ((..._: unknown[]) => unknown) ? never : T
+  ): VNode<S>
 
   // ---------------------------------------------------------------------------
 
-  // This lets you use a version of `h` which assumes your particular app state.
-  // The `_ extends never` ensures that any such state-aware `h` doesn't have
-  // an explicitly set state type that contradicts the type it actually uses.
+  // This lets you make a variant of `h()` which is aware of your Hyperapp
+  // instance's state. The `_ extends never` ensures that any state-aware
+  // `h()` doesn't have an explicit state type that contradicts the
+  // state type it actually uses.
   interface TypedH<S> {
-    <_ extends never, T extends string = string>(
-      tag: T extends "" ? never : T,
-      props: PropList<S>,
-      children?: MaybeVDOM<S> | readonly MaybeVDOM<S>[]
-    ): VDOM<S>
+    <_ extends never, C = unknown, T extends string = string>(
+      tag: NonEmptyString<T>,
+      props: CustomPayloads<S, C> & Props<S>,
+      children?: MaybeVNode<S> | readonly MaybeVNode<S>[]
+    ): VNode<S>
   }
 
-  // This helper for `h` lets event handling actions accept custom payloads.
-  type ValidateCustomPayloads<S, T> = {
-    [K in keyof T]?: K extends "style"
+  // ---------------------------------------------------------------------------
+
+  // An action transforms existing state and/or wraps another action.
+  type Action<S, P = any> = (state: S, payload: P) => Dispatchable<S>
+
+  // A Hyperapp instance typically has an initial state and a top-level view
+  // mounted over an available DOM element.
+  type App<S> =
+    Readonly<AtLeastSomething<{
+      // State is established through either direct assignment or an action.
+      init: Dispatchable<S>
+
+      // The subscriptions function manages a set of subscriptions.
+      subscriptions: (state: S) => (boolean | undefined | Subscription<S>)[]
+
+      // Dispatching can be augmented to do custom processing.
+      dispatch: (dispatch: Dispatch<S>) => Dispatch<S>
+    }, {
+      // The top-level view can build a virtual DOM node depending on the state.
+      view: (state: S) => VNode<S>
+
+      // The mount node is where a Hyperapp instance will get placed.
+      node: Node
+    }>>
+
+  // The `class` property represents an HTML class attribute string.
+  type ClassProp =
+    | boolean
+    | string
+    | undefined
+    | Record<string, boolean | undefined>
+    | ClassProp[]
+
+  // This lets event-handling actions properly accept custom payloads.
+  type CustomPayloads<S, T> = {
+    [K in keyof T]?:
+      K extends "style"
       ? StyleProp
-      : T[K] extends [Action<S, infer P>, unknown]
-      ? [Action<S, P>, P]
+      : T[K] extends [action: Action<S, infer P>, payload: unknown]
+      ? [action: Action<S, P>, payload: P]
       : T[K]
   }
 
-  // This utility type requires every property of an object or none at all.
-  // `App` uses this to make sure `view:` always appears alongside `node:`.
-  type AllOrNothing<T> = T | { [K in keyof T]?: never }
+  // Dispatching will cause state transitions.
+  type Dispatch<S> = (dispatchable: Dispatchable<S>, payload?: unknown) => void
 
-  // This utility type ensures at least one property in an object to be present.
-  // `App` uses this to conveniently invalidate `app({})` because that is
-  // basically a fancy no-op.
-  type AtLeastOne<T> = { [K in keyof T]: Pick<T, K> }[keyof T]
-  // Credit: https://stackoverflow.com/a/59987826/1935675
-
-  // This utility type validates plain objects while invalidating array objects
-  // and string objects by disallowing numerical indexing. Used by `StyleProp`.
-  type IndexableByKey = Record<number, never>
-
-  // ---------------------------------------------------------------------------
-
-  // A Hyperapp instance generally has an initial state and a base view and is
-  // mounted over an available DOM element.
-  type App<S> = Readonly<
-    | {
-        view: View<S>
-        node: Node
-      }
-    | (AtLeastOne<{
-        init: Dispatchable<S>
-        subscriptions: Subscriptions<S>
-        dispatch: DispatchInitializer<S>
-      }> &
-        AllOrNothing<{
-          view: View<S>
-          node: Node
-        }>)
-  >
-
-  // A view builds a virtual DOM node representation of the application state.
-  type View<S> = (state: S) => VDOM<S>
-
-  // The subscriptions function manages a set of subscriptions.
-  type Subscriptions<S> = (
-    state: S
-  ) => (boolean | undefined | Subscription<S> | Unsubscribe)[]
-
-  // A subscription reacts to external activity.
-  type Subscription<S, P = any> = [
-    subscriber: (dispatch: Dispatch<S>, payload: P) => void | Unsubscribe,
-    payload: P
-  ]
-
-  // An unsubscribe function cleans up a canceled subscription.
-  type Unsubscribe = () => void
-
-  // Dispatching can be augmented to do custom processing.
-  type DispatchInitializer<S> = (dispatch: Dispatch<S>) => Dispatch<S>
-
-  // ---------------------------------------------------------------------------
-
-  // A dispatched action handles an event in the context of the current state.
-  type Dispatch<S> = (dispatchable: Dispatchable<S>, payload?: any) => void
-
-  // A dispatchable entity, when processed, causes a state transition.
+  // A dispatchable entity is used to cause a state transition.
   type Dispatchable<S, P = any> =
     | S
     | [state: S, ...effects: Effect<S, P>[]]
     | Action<S, P>
     | [action: Action<S, P>, payload: P]
 
-  // An action transforms existing state and/or wraps another action.
-  type Action<S, P = any> = (state: S, payload: P) => Dispatchable<S>
-
   // An effect is where side effects and any additional dispatching may occur.
-  type Effect<S, P = any> = [
+  type Effect<S, P = unknown> = [
     effecter: (dispatch: Dispatch<S>, payload: P) => void | Promise<void>,
     payload: P
   ]
 
-  // ---------------------------------------------------------------------------
-
-  // A virtual DOM node represents an actual DOM element.
-  type VDOM<S> = {
-    readonly type: VDOMNodeType
-    readonly props: PropList<S>
-    readonly children: MaybeVDOM<S>[]
-    node: null | undefined | Node
-    readonly tag: Tag<S>
-    readonly key: Key
-    memo?: PropList<S>
-    events?: Record<string, Action<S> | [action: Action<S>, payload: any]>
-
-    // `_VDOM` is a guard property which gives us a way to tell `VDOM` objects
-    // apart from `PropList` objects. Since we don't expect users to manually
-    // create their own VNodes, we can take advantage of this trick that's
-    // specific to TypeScript without forcing the user to do
-    // anything different.
-    _VDOM: true
-  }
-
-  // These are based on actual DOM node types:
-  // https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
-  const enum VDOMNodeType {
-    SSR = 1,
-    Text = 3,
+  // Event handlers are implemented using actions.
+  type EventActions<S> = {
+    [K in keyof EventsMap]:
+      | Action<S, EventsMap[K]>
+      | [action: Action<S>, payload: unknown]
   }
 
   // In certain places a virtual DOM node can be made optional.
-  type MaybeVDOM<S> = boolean | null | undefined | VDOM<S>
-
-  // A virtual DOM node's tag has metadata relevant to it. Virtual DOM nodes are
-  // tagged by their type to assist rendering.
-  type Tag<S> = string | View<S>
-
-  // A key can uniquely associate a virtual DOM node with a certain DOM element.
-  type Key = string | null | undefined
+  type MaybeVNode<S> = boolean | null | undefined | VNode<S>
 
   // Virtual DOM properties will often correspond to HTML attributes.
-  type PropList<S> =
+  type Props<S> =
     Readonly<
       Partial<
         Omit<HTMLElement, keyof (
@@ -178,49 +150,60 @@ declare module "hyperapp" {
       {
         [_: string]: unknown
         class?: ClassProp
-        key?: Key
+        key?: VNode<S>["key"]
         style?: StyleProp
 
-        // By disallowing `_VDOM` we ensure that values having the `VDOM` type
-        // are not mistaken for also having `PropList`.
-        _VDOM?: never
+        // By disallowing `_VNode` we ensure values having the `VNode` type are
+        // not mistaken for also having the `Props` type.
+        _VNode?: never
       }
     >
 
-  // The `class` property represents an HTML class attribute string.
-  type ClassProp =
-    | boolean
-    | string
-    | undefined
-    | Record<string, boolean | undefined>
-    | ClassProp[]
-
-  // The `style` property represents inline CSS.
-  //
-  // NOTE: This relies on what TypeScript itself recognizes as valid CSS
-  // properties. Custom properties are not covered as well as any newer
-  // properties that are not yet recognized by TypeScript. Apparently,
-  // the only way to accommodate them is to relax the adherence to
-  // TypeScript's CSS property definitions. The trade-off doesn't
-  // seem worth it given the chances of using such properties.
-  // However, you can use type casting if you want to them.
-  type StyleProp = IndexableByKey &
-    {
-      [K in keyof CSSStyleDeclaration]?: CSSStyleDeclaration[K] | null
-    }
-
-  // Event handlers are implemented using actions.
-  type EventActions<S> = {
-    [K in keyof EventsMap]:
-      | Action<S, EventsMap[K]>
-      | [action: Action<S>, payload: any]
+  // The `style` property represents inline CSS. This relies on TypeScript's CSS
+  // property definitions. Custom properties aren't covered as well as any newer
+  // properties yet to be recognized by TypeScript. The only way to accommodate
+  // them is to relax the adherence to TypeScript's CSS property definitions.
+  // It's a poor trade-off given the likelihood of using such properties.
+  // However, you can use type casting if you want to use them.
+  type StyleProp = IndexableByKey & {
+    [K in keyof CSSStyleDeclaration]?: CSSStyleDeclaration[K] | null
   }
 
-  // Most event typings are provided by TypeScript itself.
-  type EventsMap = {
-    [K in keyof HTMLElementEventMap as `on${K}`]: HTMLElementEventMap[K]
-  } &
-    { [K in keyof WindowEventMap as `on${K}`]: WindowEventMap[K] } & {
-      onsearch: Event
-    }
+  // A subscription reacts to external activity.
+  type Subscription<S, P = unknown> = [
+    subscriber: (dispatch: Dispatch<S>, payload: P) => void | Unsubscribe,
+    payload: P
+  ]
+
+  // An unsubscribe function cleans up a canceled subscription.
+  type Unsubscribe = () => void
+
+  // A virtual DOM node (a.k.a. VNode) represents an actual DOM element.
+  type VNode<S> = {
+    readonly props: Props<S>
+    readonly children: MaybeVNode<S>[]
+    node: null | undefined | Node
+
+    // Hyperapp takes care of using native Web platform event handlers for us.
+    events?: Record<string, Action<S> | [action: Action<S>, payload: unknown]>
+
+    // A key can uniquely associate a VNode with a certain DOM element.
+    readonly key: string | null | undefined
+
+    // A VNode's tag is either an element name or a memoized view function.
+    readonly tag: string | ((data: Indexable) => VNode<S>)
+
+    // If the VNode's tag is a function then this data will get passed to it.
+    memo?: Indexable
+
+    // VNode types are based on actual DOM node types:
+    // https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
+    readonly type: 1 | 3
+
+    // `_VNode` is a phantom guard property which gives us a way to tell `VNode`
+    // objects apart from `Props` objects. Since we don't expect users to make
+    // their own VNodes manually, we can take advantage of this trick which
+    // is unique to TypeScript type definitions for JavaScript code.
+    _VNode: true
+  }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -121,7 +121,7 @@ declare module "hyperapp" {
     | readonly [action: Action<S, P>, payload: P]
 
   // An effect is where side effects and any additional dispatching may occur.
-  type Effect<S, P = unknown> = readonly [
+  type Effect<S, P = any> = readonly [
     effecter: (dispatch: Dispatch<S>, payload: P) => void | Promise<void>,
     payload: P
   ]
@@ -171,7 +171,7 @@ declare module "hyperapp" {
   }
 
   // A subscription reacts to external activity.
-  type Subscription<S, P = unknown> = readonly [
+  type Subscription<S, P = any> = readonly [
     subscriber: (dispatch: Dispatch<S>, payload: P) => void | Unsubscribe,
     payload: P
   ]


### PR DESCRIPTION
Refactoring, fixing, and streamlining is the theme of this update.

The biggest change is now the set of publicly available types have been trimmed down to these:

|                |                |                |                  |            |
| -------------- | -------------- | -------------- | ---------------- | ---------- |
| `Action`       | `App`          | `ClassProp`    | `CustomPayloads` | `Dispatch`
| `Dispatchable` | `Effect`       | `EventActions` | `MaybeVNode`     | `Props`
| `StyleProp`    | `Subscription` | `TypedH`       | `Unsubscribe`    | `VNode`

Relevant GitHub discussion: https://github.com/jorgebucaran/hyperapp/discussions/1052

Changelog:

- Added missing custom payload validation in `TypedH`.
- Removed `Unsubscribe` from `Subscriptions`.
- Inlined `DispatchInitializer`, `Key`, `Subscriptions`, `Tag`, `VDOMNodeType`, and `View`.
- Fixed the return type of the view function parameter of `memo()`.
- Increased type accuracy of data for memoized views which resulted in the creation of the `Indexable` utility type.
- Refactored `App` which resulted in the creation of the `AtLeastSomething` utility type.
- Made `EventsMap` and all utility types private.
- Used `unknown` (the type-safe version of `any`) instead of `any` where possible while preserving DX.
- Renamed `ValidateCustomPayloads` to `CustomPayloads`.
- Renamed `PropList` to `Props`.
- Renamed `VDOM` to `VNode`.
- Renamed `MaybeVDOM` to `MaybeVNode`.
- Alphabetized private types.
- Alphabetized public types.
- Worked on commentary and formatting.

Updates as of 2021-04-23, 12:07 PM EST:

- Expanded usage of `readonly` arrays and `readonly` tuples.
  - Should be particularly good for `app()`'s `subscriptions:` property since doing things like growing or shrinking the subscriptions array would mess up how subscriptions are handled.
- Restored usage of `any` as the default payload type for `Subscription` and `Effect` because it has better DX than it has with using `unknown` as the default.
- Made it a requirement for subscribers to return an unsubscriber function.
