### PR TITLE
improve types dx

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,7 +38,7 @@ declare module "hyperapp" {
     tag: NonEmptyString<T>,
     props: CustomPayloads<S, C> & Props<S>,
     children?: MaybeVNode<S> | readonly MaybeVNode<S>[]
-  ): VNode<S>
+  ): ElementVNode<S>
 
   // `memo()` stores a view along with any given data for it.
   function memo<S, D extends Indexable = Indexable>(
@@ -47,10 +47,10 @@ declare module "hyperapp" {
   ): VNode<S>
 
   // `text()` creates a virtual DOM node representing plain text.
-  function text<S, T = unknown>(
+  function text<T = unknown>(
     // Values, aside from symbols and functions, can be handled.
     value: T extends symbol | ((..._: unknown[]) => unknown) ? never : T
-  ): VNode<S>
+  ): TextVNode
 
   // ---------------------------------------------------------------------------
 
@@ -63,7 +63,7 @@ declare module "hyperapp" {
       tag: NonEmptyString<T>,
       props: CustomPayloads<S, C> & Props<S>,
       children?: MaybeVNode<S> | readonly MaybeVNode<S>[]
-    ): VNode<S>
+    ): ElementVNode<S>
   }
 
   // ---------------------------------------------------------------------------
@@ -180,7 +180,7 @@ declare module "hyperapp" {
   type Unsubscribe = () => void
 
   // A virtual DOM node (a.k.a. VNode) represents an actual DOM element.
-  type VNode<S> = {
+  type ElementVNode<S> = {
     readonly props: Props<S>
     readonly children: readonly MaybeVNode<S>[]
     node: null | undefined | Node
@@ -203,7 +203,7 @@ declare module "hyperapp" {
 
     // VNode types are based on actual DOM node types:
     // https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
-    readonly type: 1 | 3
+    readonly type: 1
 
     // `_VNode` is a phantom guard property which gives us a way to tell `VNode`
     // objects apart from `Props` objects. Since we don't expect users to make
@@ -211,4 +211,18 @@ declare module "hyperapp" {
     // is unique to TypeScript type definitions for JavaScript code.
     _VNode: true
   }
+
+  // Certain VNodes specifically represent Text nodes and don't rely on state.
+  type TextVNode = {
+    readonly props: {}
+    readonly children: []
+    node: null | undefined | Node
+    readonly key: undefined
+    readonly tag: string
+    readonly type: 3
+    _VNode: true
+  }
+  
+  // VNodes may represent either Text or Element nodes.
+  type VNode<S> = ElementVNode<S> | TextVNode
 }


### PR DESCRIPTION
Improves the DX of the types without relaxing any constraints. (As far as I can tell)

First: we distinguish between ElementVNodes and TextVNodes. That is important because ElementVNodes should be generic – parameterised on the state, so that various actions in a tree all work on the same state. This does not apply to text-nodes which a) have no actions assigned to them, and b) are always leaf-nodes (no children). For that reason, it doesn't make sense for text-nodes to be parameterized on the state, and also it doesn't make sense for the `text()` function to be a generic function.

Second: Whenever there are nodes, or parts of the tree that don't contain any actions, that part of the view tree will end up having the type `ElementVNode<unknown>` (prev `VNode<unknonw>`).
If such a node has siblings that are `VNode<SomeKNownState>` there will be a type error unless you explicitly pass the SomeKnownState as a generic to the `h` functions. This get's troublesome fast – especially when you are using JSDoc to type reusable components (which should not be aware of the state). 

How I fixed that was simply to allow: `MaybeVNode<S> = boolean | VNode<S> | ElementVNode<unknown>` As far as I can see that fixed all inference trouble for me, without relaxing anything (the State is still properly inferred and doesent "bail out" to any or unknown)