### PR TITLE
Allow bare effecter as effect

### DIFF
--- a/docs/architecture/effects.md
+++ b/docs/architecture/effects.md
@@ -9,7 +9,7 @@ As with [subscriptions](subscriptions.md), effects are used to deal with impure 
 **_Signature:_**
 
 ```elm
-Effect : EffecterFn | [EffecterFn, Payload?]
+Effect : EffecterFn | [EffecterFn, Payload]
 ```
 
 **_Naming Recommendation:_**

--- a/docs/architecture/effects.md
+++ b/docs/architecture/effects.md
@@ -9,7 +9,7 @@ As with [subscriptions](subscriptions.md), effects are used to deal with impure 
 **_Signature:_**
 
 ```elm
-Effect : [EffecterFn, Payload?]
+Effect : EffecterFn | [EffecterFn, Payload?]
 ```
 
 **_Naming Recommendation:_**

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -490,14 +490,13 @@ The way to run arbitrary code with some action, is to wrap that code in a functi
 ```js
 const Select = (state, selected) => [
   {...state, selected},
-  [() => {
+  () => 
     fetch("https://jsonplaceholder.typicode.com/users/" + state.ids[selected])
     .then(response => response.json())
     .then(data => {
       console.log("Got data: ", data)
       /* now what ? */
     })
-  }]
 ]
 ```
 
@@ -507,11 +506,11 @@ When an action returns something like `[newState, [function]]`, the function is 
 ```js
 const Select = (state, selected) => [
   {...state, selected},
-  [dispatch => {                           // <---
+  dispatch => {                           // <---
     fetch("https://jsonplaceholder.typicode.com/users/" + state.ids[selected])
     .then(response => response.json())
     .then(data => dispatch(GotBio, data)) // <---
-  }]
+  }
 ]
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -120,16 +120,16 @@ declare module "hyperapp" {
     | Action<S, P>
     | readonly [action: Action<S, P>, payload: P]
 
-  // An Effecter is the function that runs an effect
+  // An effecter is the function that runs an effect.
   type Effecter<S, P = any> = (
     dispatch: Dispatch<S>,
-    payload?: P
+    payload: P
   ) => void | Promise<void>
 
   // An effect is where side effects and any additional dispatching may occur.
   type Effect<S, P = any> =
     | Effecter<S, P>
-    | readonly [effecter: Effecter<S, P>, payload?: P]
+    | readonly [effecter: Effecter<S, P>, payload: P]
 
   
   // Effects can be declared conditionally.

--- a/index.d.ts
+++ b/index.d.ts
@@ -120,11 +120,17 @@ declare module "hyperapp" {
     | Action<S, P>
     | readonly [action: Action<S, P>, payload: P]
 
+  // An Effecter is the function that runs an effect
+  type Effecter<S, P = any> = (
+    dispatch: Dispatch<S>,
+    payload?: P
+  ) => void | Promise<void>
+
   // An effect is where side effects and any additional dispatching may occur.
-  type Effect<S, P = any> = readonly [
-    effecter: (dispatch: Dispatch<S>, payload: P) => void | Promise<void>,
-    payload: P
-  ]
+  type Effect<S, P = any> =
+    | Effecter<S, P>
+    | readonly [effecter: Effecter<S, P>, payload?: P]
+
   
   // Effects can be declared conditionally.
   type MaybeEffect<S, P> = null | undefined | boolean | "" | 0 | Effect<S, P>

--- a/index.js
+++ b/index.js
@@ -409,7 +409,7 @@ export var app = ({
           : action
               .slice(1)
               .map(
-                (fx) => fx && fx !== true && fx[0](dispatch, fx[1]),
+                (fx) => fx && fx !== true && (fx[0] || fx)(dispatch, fx[1]),
                 update(action[0])
               )
         : update(action)


### PR DESCRIPTION
The idea behind this PR is to create some more symmetry in the API. 

An action can be dispatched on it's own (a bare function):

```js
onclick: SomeAction
```

or with a custom payload:

```js
onclick: [SomeAction, {foo: 'bar'}]
```

But when returning effects from actions, they need to be given as tuples (in square brackets), regardless if the effecter function needs a payload or not. I e:

```js
const doSomethingFx = () =>  {alert('I did something')}

const JustDoSomething = (state) => [state, [doSomethingFx]]
```

This PR would allow giving just the bare effecter when it does not require any parameters:

```js
const JustDoSomething = (state) => [state, doSomethingFx]
```

I admit this is not a common need and thus not a huge deal. But the change is small, and make the api more flexible and symmetrical (imo) without violating any principles or any breaking changes.