### PR TITLE
Apps doc page refactor

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1,12 +1,10 @@
 # `app()`
 
 <big><pre>
-app : ({ <a href="#init">init</a>, <a href="#view">view</a>, <a href="#node">node</a>, <a href="#subscriptions">subscriptions?</a>, <a href="#dispatch">dispatch?</a> }) -> DispatchFn
+app : ({ <a href="#init">init?</a>, <a href="#view">view</a>, <a href="#node">node</a>, <a href="#subscriptions">subscriptions?</a>, <a href="#dispatch">dispatch?</a> }) -> DispatchFn
 </pre></big>
 
-Initialize and mount a Hyperapp application.
-
-(`subscriptions` and `dispatch` are optional)
+Initialize and mount a Hyperapp application. `init`, `subscriptions` and `dispatch` are optional.
 
 ```js
 import { app } from "hyperapp"
@@ -14,7 +12,8 @@ import { app } from "hyperapp"
 app({
   init: { message: 'hello world' },
   view: state => h("p", {}, text(state.message)),
-  node: document.getElementById('app')
+  node: document.getElementById('app'),
+  subscriptions: state => [ onKey("w", MoveForward) ],  
 })
 ```
 <br/>
@@ -30,7 +29,7 @@ init: { state }
 
 Initialize the app. Takes place before the first view render and subscriptions registration.  
 
-Note that if you leave `init:` undefined the state will be set to an empty object (`{}`) by default.
+If omitted the state will be set to an empty object (`{}`) by default.
 <br/>
 
 **Signatures:** 
@@ -137,7 +136,6 @@ A [Dispatch Initializer](../architecture/dispatch.md#dispatch-initializer) that 
 
 ### Other Considerations
 
-- You can embed your Hyperapp application within an already existing app that was built with some other framework. This can be useful for migrating to Hyperapp in a systematic way or just using Hyperapp for a particular purpose.
+- You can embed your Hyperapp application within an already existing app that was built with some other framework. 
 
-- Multiple Hyperapp applications can coexist on the page simultaneously. They each have their own state and behave independently relative to each other.  
-If they need to communicate with each other, then subscriptions and effects for each app can be used for that purpose.
+- Multiple Hyperapp applications can coexist on the page simultaneously. They each have their own state and behave independently relative to each other. They can communicate with each other using subscriptions and effects (ie using events).

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -64,13 +64,13 @@ Note that if you leave `init:` undefined the state will be set to an empty objec
     // ...
   }
   ```
+<br/>
 
-
-#### `view:`
+### `view:`
 
 The [top-level view](../architecture/views.md#top-level-view) that represents the app as a whole. There can only be one top-level view in your app.
 
-Hyperapp uses this to map your state to your UI for rendering the app. Every time the state of your application changes, this function will be called again to render the UI based on the new state, using the logic you've defined inside of it.
+Hyperapp uses this to map your state to your UI for rendering the app. Every time the [state](../architecture/state.md) of the application changes, this function will be called to render the UI based on the new state, using the logic you've defined inside of it.
 
 ```js
 app({
@@ -83,10 +83,13 @@ app({
 ```
 
 <!-- "Outworld" and "Netherrealm" are two of several realms in the "Mortal Kombat" videogame series. -->
+<br/>
 
-#### `node:`
+### `node:`
 
-The DOM element to render the virtual DOM over. Also known as the **mount node**. It's common to define an intentionally empty element in your HTML which has an ID that your app can use for mounting.
+The DOM element to render the virtual DOM over (the "mount node"). The given element is replaced by a Hyperapp application ("mounting").  
+It's common to define an intentionally empty element in your HTML which has an ID that your app can use for mounting.  
+If the mount node had content within it then Hyperapp will attempt to [recycle](../architecture/views.md#recycling) that content.
 
 ```html
 <main id="app"></main>
@@ -98,95 +101,41 @@ app({
   node: document.getElementById("app"),
 })
 ```
+<br/>
 
-##### Mounting
+### `subscriptions:`
 
-The process of **mounting** means that a given DOM node is replaced by a Hyperapp application that gets initialized.
-
-If the **mount node** had content within it then Hyperapp will attempt to [recycle](../architecture/views.md#recycling) that content.
-
-#### `subscriptions:`
-
-A function that returns an array of [subscriptions](../architecture/subscriptions.md) for a given state.
-
-In a similar fashion to how [views](../architecture/views.md) are used to dynamically add and remove DOM elements based on the state, this _subscriptions_ function is used for dynamically adding and removing subscriptions to the app.
+A function that returns an array of [subscriptions](../architecture/subscriptions.md) for a given state.  
+Every time the [state](../architecture/state.md) of the application changes, this function will be called to determine the current subscriptions.
 
 ```js
 import { onKey } from "./subs"
 
-// ...
-
 app({
-  view: (state) =>
-    h("div", {}, [
-      state.playing && viewLevel(),
-      h("p", {}, text("Rip and Tear!")),
-    ]),
-  subscriptions: (state) => [
+  // ...
+  subscriptions: state => [
     onKey("w", MoveForward),
-    onKey("a", MoveBackward),
-    onKey("s", StrafeLeft),
-    onKey("d", StrafeRight),
-    state.playingDOOM1993 || onKey(" ", Jump),
-  ],
+    onKey("a", MoveBackward)
+  ]
 })
 ```
+<br/>
 
-<!-- The 1993 videogame DOOM did not have jumping as a movement option. "Rip and Tear!" was one of the infamous quotes of the protagonist DoomGuy in the 1996 Doom comic "Knee Deep in the Dead". -->
+### `dispatch:`
 
-#### `dispatch:`
+A [Dispatch Initializer](../architecture/dispatch.md#dispatch-initializer) that can create a [custom dispatch function](../architecture/dispatch.md#custom-dispatching) to use instead of the default dispatch.
 
-A dispatch initializer that can create a [custom dispatch function](../architecture/dispatch.md#custom-dispatching) to use instead of the default dispatch.
+<br/>
 
----
-
-## Instrumentation
+### Instrumentation
 
 `app()` returns the [dispatch](../architecture/dispatch.md) function your app uses. This can be handy if you want to [control your app externally](#usage-within-non-hyperapp-projects).
 
----
+<br/>
 
-## Examples
+### Other Considerations
 
-### Regular Usage
+- You can embed your Hyperapp application within an already existing app that was built with some other framework. This can be useful for migrating to Hyperapp in a systematic way or just using Hyperapp for a particular purpose.
 
-```js
-app({
-  init: { message: "Hello, World!" },
-  view: (state) => h("main", {}, h("p", {}, text(state.message))),
-  node: document.querySelector("main"),
-})
-```
-
-<!-- A "Hello, World!" program is traditionally the first program you would write when learning a new programming language. -->
-
-### Full Usage
-
-```js
-app({
-  init: { message: "Hello, World!" },
-  view: (state) => h("main", {}, h("p", {}, text(state.message))),
-  node: document.querySelector("main"),
-  subscriptions: (state) => [sub1, sub2],
-  dispatch: (dispatch) => (action, payload) => {
-    dispatch((state) => ({ ...state, message: `${state.message}!` }))
-    dispatch(action, payload)
-  },
-})
-```
-
----
-
-## Other Considerations
-
-### Usage Within Non-Hyperapp Projects
-
-You can embed your Hyperapp application within an already existing app that was built with some other framework. This can be useful for migrating to Hyperapp in a systematic way or just using Hyperapp for a particular purpose.
-
-### Multiple Apps
-
-Multiple Hyperapp applications can coexist on the page simultaneously. They each have their own state and behave independently relative to each other.
-
+- Multiple Hyperapp applications can coexist on the page simultaneously. They each have their own state and behave independently relative to each other.  
 If they need to communicate with each other, then subscriptions and effects for each app can be used for that purpose.
-
-However, if one is nested within another, then the containing app would naturally have more control over the nested app, not only by controlling what can be used for the nested app's [mount node](#node) but also by utilizing the nested app's [returned dispatch function](#instrumentation).

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -20,16 +20,6 @@ app(props)
 app : ({ Init, View, Node, Subscriptions?, Dispatch? }) -> DispatchFn
 ```
 
-| Parameter       | Type   | Required? |
-| --------------- | ------ | --------- |
-| [props](#props) | Object | yes :100: |
-
-| Return Value                            | Type     |
-| --------------------------------------- | -------- |
-| [dispatch](../architecture/dispatch.md) | Function |
-
----
-
 ## Parameters
 
 ### `props`
@@ -46,29 +36,35 @@ There are only a handful of props you can use to configure your app.
 
 #### `init:`
 
-Initial value of the [state](../architecture/state.md) or an [action](../architecture/actions.md) to take to initialize the state.
+```js
+init: { firstState }
+      | [firstState, ...effects ]
+      | initAction
+      | [initAction, payload? ]
+```
 
-You can simply set the initial state directly:
+Initialize the app
+
+`init: { firstState }` sets the initial state directly:
 
 ```js
 app({
+  init: { counter: 0 },
   // ...
-  init: { problems: 99 },
 })
 ```
 
+`init: [firstState, ...effects ]` sets the initial state and run the given [effects](../architecture/effects.md):
 <!-- The initial state is a play on Jay-Z's song "99 Problems". -->
 
-Or you can use the various types of [actions](../architecture/actions.md) to do things like fetching initial data for your app.
-
 ```js
-import { butASPAAintOne } from "./fx"
+import { fetch  } from "./fx"
 
 app({
   // ...
-  init: (problems = 99) => [
+  init: [
     { loading: true }, 
-    butASPAAintOne(problems)
+    fetch(problems)
   ],
 })
 ```

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -6,6 +6,8 @@ app : ({ <a href="#init">init</a>, <a href="#view">view</a>, <a href="#node">nod
 
 Initialize and mount a Hyperapp application.
 
+(`subscriptions` and `dispatch` are optional)
+
 ```js
 import { app } from "hyperapp"
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1,77 +1,70 @@
 # `app()`
 
-**_Definition:_**
+<big><pre>
+app : ({ <a href="#init">init</a>, <a href="#view">view</a>, <a href="#node">node</a>, <a href="#subscriptions">subscriptions?</a>, <a href="#dispatch">dispatch?</a> }) -> DispatchFn
+</pre></big>
 
-> A function that initializes and mounts a Hyperapp application.
-
-**_Import & Usage:_**
+Initialize and mount a Hyperapp application.
 
 ```js
 import { app } from "hyperapp"
 
-// ...
-
-app(props)
-```
-
-**_Signature & Parameters:_**
-
-```elm
-app : ({ Init, View, Node, Subscriptions?, Dispatch? }) -> DispatchFn
-```
-
-## Parameters
-
-### `props`
-
-There are only a handful of props you can use to configure your app.
-
-| Prop                            | Type                                                                      | Required? |
-| ------------------------------- | ------------------------------------------------------------------------- | --------- |
-| [init](#init)                   | [State](../architecture/state.md) or [Action](../architecture/actions.md) | yes :100: |
-| [view](#view)                   | [View](../architecture/views.md)                                          | yes :100: |
-| [node](#node)                   | DOM element                                                               | yes :100: |
-| [subscriptions](#subscriptions) | Function                                                                  | no        |
-| [dispatch](#dispatch)           | [Dispatch Initializer](../architecture/dispatch.md#dispatch-initializer)  | no        |
-
-#### `init:`
-
-```js
-init: { firstState }
-      | [firstState, ...effects ]
-      | initAction
-      | [initAction, payload? ]
-```
-
-Initialize the app
-
-`init: { firstState }` sets the initial state directly:
-
-```js
 app({
-  init: { counter: 0 },
-  // ...
+  init: { message: 'hello world' },
+  view: state => h("p", {}, text(state.message)),
+  node: document.getElementById('app')
 })
 ```
+<br/>
 
-`init: [firstState, ...effects ]` sets the initial state and run the given [effects](../architecture/effects.md):
-<!-- The initial state is a play on Jay-Z's song "99 Problems". -->
+### `init:`
 
 ```js
-import { fetch  } from "./fx"
-
-app({
-  // ...
-  init: [
-    { loading: true }, 
-    fetch(problems)
-  ],
-})
+init: { state }
+      | [state, ...effects ]
+      | Action
+      | [Action, payload? ]
 ```
 
-<!-- The initial action taken is a play on Jay-Z's song "99 Problems". -->
+Initialize the app. Takes place before the first view render and subscriptions registration.  
 
 Note that if you leave `init:` undefined the state will be set to an empty object (`{}`) by default.
+<br/>
+
+**Signatures:** 
+
+- `init: { state }` sets the initial state directly:
+
+  ```js
+  app({
+    init: { counter: 0 },
+    // ...
+  })
+  ```
+
+- `init: [state, ...effects ]` sets the initial state and run the given [effects](../architecture/effects.md):
+
+  ```js
+  app({
+    init: [ { loading: true }, fetch('myurl?init', DoneAction) ],
+    // ...
+  })
+  ```
+
+- `init: Action` and `init: [Action, payload? ]` run the given [Action](../architecture/action.md):
+
+  This form is useful when the Action can be reused later.  
+  The state passed to the Action in this case is `undefined`  
+
+  ```js
+  const Reset = state => { counter: 0 }
+
+  app({
+    init: Reset,
+    // ...
+  }
+  ```
+
 
 #### `view:`
 


### PR DESCRIPTION
Some work towards refactoring of the app.md page

This is an initial stub for discussion.

Looking for general opinions ! am I barking up the wrong tree ?

also:
- should the init breakdown here move to a separate page
- should the example use hyperlit which imo looks much more inviting
- should this page mention cleanup
