### PR TITLE
Less class patching

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ var enqueue =
 var createClass = (obj) => {
   var out = ""
 
-  if (typeof obj === "string") return obj
+  if (!obj || typeof obj === "string") return obj
 
   if (isArray(obj)) {
     for (var k = 0, tmp; k < obj.length; k++) {
@@ -69,8 +69,7 @@ var patchSubs = (oldSubs, newSubs = EMPTY_ARR, dispatch) => {
 var getKey = (vdom) => (vdom == null ? vdom : vdom.key)
 
 var patchProperty = (node, key, oldValue, newValue, listener, isSvg) => {
-  if (key === "key") {
-  } else if (key === "style") {
+  if (key === "style") {
     for (var k in { ...oldValue, ...newValue }) {
       oldValue = newValue == null || newValue[k] == null ? "" : newValue[k]
       if (k[0] === "-") {
@@ -89,11 +88,7 @@ var patchProperty = (node, key, oldValue, newValue, listener, isSvg) => {
     }
   } else if (!isSvg && key !== "list" && key !== "form" && key in node) {
     node[key] = newValue == null ? "" : newValue
-  } else if (
-    newValue == null ||
-    newValue === false ||
-    (key === "class" && !(newValue = createClass(newValue)))
-  ) {
+  } else if (newValue == null || newValue === false) {
     node.removeAttribute(key)
   } else {
     node.setAttribute(key, newValue)
@@ -348,10 +343,10 @@ var recycleNode = (node) =>
         node
       )
 
-var createVNode = (tag, props, children, type, node) => ({
+var createVNode = (tag, { key, ...props }, children, type, node) => ({
   tag,
   props,
-  key: props.key,
+  key,
   children,
   type,
   node,
@@ -362,8 +357,12 @@ export var memo = (tag, memo) => ({ tag, memo })
 export var text = (value, node) =>
   createVNode(value, EMPTY_OBJ, EMPTY_ARR, TEXT_NODE, node)
 
-export var h = (tag, props, children = EMPTY_ARR) =>
-  createVNode(tag, props, isArray(children) ? children : [children])
+export var h = (tag, { class: c, ...p }, children = EMPTY_ARR) =>
+  createVNode(
+    tag,
+    { ...p, class: createClass(c) },
+    isArray(children) ? children : [children]
+  )
 
 export var app = ({
   node,

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ var enqueue =
 var createClass = (obj) => {
   var out = ""
 
-  if (!obj || typeof obj === "string") return obj
+  if (typeof obj === "string") return obj
 
   if (isArray(obj)) {
     for (var k = 0, tmp; k < obj.length; k++) {
@@ -357,7 +357,7 @@ export var memo = (tag, memo) => ({ tag, memo })
 export var text = (value, node) =>
   createVNode(value, EMPTY_OBJ, EMPTY_ARR, TEXT_NODE, node)
 
-export var h = (tag, { class: c, ...p }, children = EMPTY_ARR) =>
+export var h = (tag, { class: c = "", ...p }, children = EMPTY_ARR) =>
   createVNode(
     tag,
     { ...p, class: createClass(c) },


### PR DESCRIPTION
Fixes #1078 

When defining classes in "object form" (i e: `h('div', {class: {foo: true, bar: false, baz: true}})`) hyperapp converts that form into the usual string form (`"foo baz"`)  _but_ not until _after_ it has compared the current class prop to the previous vnode's class prop. 

Since `{} !== {}` there will always be a diff when comparing. Meaning this conversion, and subsequent patching of the DOM node will occur on _every_ update wether it is actually needed or not. 

This PR fixes the situation by normalizing the class property to a string directly in the `h` function. This way class-props are only patched in the DOM when they have actually changed. 

(Also I snuck in a small improvement regarding how keys are handled to help me keep the byte-diff down)