### PR TITLE
Prevent unnecssary patching of class attribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -357,10 +357,10 @@ export var memo = (tag, memo) => ({ tag, memo })
 export var text = (value, node) =>
   createVNode(value, EMPTY_OBJ, EMPTY_ARR, TEXT_NODE, node)
 
-export var h = (tag, { class: c = "", ...p }, children = EMPTY_ARR) =>
+export var h = (tag, { class: c, ...props }, children = EMPTY_ARR) =>
   createVNode(
     tag,
-    { ...p, class: createClass(c) },
+    { ...props, ...(c ? { class: createClass(c) } : EMPTY_OBJ) },
     isArray(children) ? children : [children]
   )
 


### PR DESCRIPTION
A second more correct attempt that doesn't enforce a `class` property on every vnode at the cost of just a couple more bytes