### PR TITLE
remove setTimeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,10 +7,6 @@ var SVG_NS = "http://www.w3.org/2000/svg"
 var id = (a) => a
 var map = EMPTY_ARR.map
 var isArray = Array.isArray
-var enqueue =
-  typeof requestAnimationFrame !== "undefined"
-    ? requestAnimationFrame
-    : setTimeout
 
 var createClass = (obj) => {
   var out = ""
@@ -380,7 +376,10 @@ export var app = ({
     if (state !== newState) {
       if ((state = newState) == null) dispatch = subscriptions = render = id
       if (subscriptions) subs = patchSubs(subs, subscriptions(state), dispatch)
-      if (view && !busy) enqueue(render, (busy = true))
+      if (view && !busy) {
+        requestAnimationFrame(render)
+        busy = true;
+      }
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -378,7 +378,7 @@ export var app = ({
       if (subscriptions) subs = patchSubs(subs, subscriptions(state), dispatch)
       if (view && !busy) {
         requestAnimationFrame(render)
-        busy = true;
+        busy = true
       }
     }
   }


### PR DESCRIPTION
This PR does two things:
1. remove the fallback to `setTimeout` if RAF is not available. In such rare environments RAF can be replaced externally.
2. move the assignment `busy=true` to a separate line to increase code readability.

I tested on a few of the available codepen examples simply replacing the hyperapp link with https://raw.githack.com/kofifus/hyperapp/patch-1/index.js
