### PR TITLE
Remove `setTimeout` fallback 

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,10 +7,6 @@ var SVG_NS = "http://www.w3.org/2000/svg"
 var id = (a) => a
 var map = EMPTY_ARR.map
 var isArray = Array.isArray
-var enqueue =
-  typeof requestAnimationFrame !== "undefined"
-    ? requestAnimationFrame
-    : setTimeout
 
 var createClass = (obj) => {
   var out = ""
@@ -380,7 +376,7 @@ export var app = ({
     if (state !== newState) {
       if ((state = newState) == null) dispatch = subscriptions = render = id
       if (subscriptions) subs = patchSubs(subs, subscriptions(state), dispatch)
-      if (view && !busy) enqueue(render, (busy = true))
+      if (view && !busy) requestAnimationFrame(render, (busy = true))
     }
   }
 


### PR DESCRIPTION
Previously effects were deferred using `requestAnimationFrame` which caused runtime errors when using hyperapp in non-DOM environments such as node.js or chrome-extensions.  Even when using hyperapp in headless mode (Ie not intending to render anything). To prevent such runtime errors hyperapp would fallback to using setTimeout in such cases.

That is no longer true, and even if we remove the fallback hyperapp in headless mode on node.js works fine. Hence we can shave off a few bytes here.

(this PR replaces #1092 @kofifus @sergey-shpak @jorgebucaran )

