### PR TITLE
Fix typo in api url

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -582,7 +582,7 @@ Change `init` to:
 ```js
 [
   {names: [], highlight: [], selected: null, bio: "", ids: []},
-  jsonFetcher("https://jsonplaceholder.typicode.com/posts", GotNames)
+  jsonFetcher("https://jsonplaceholder.typicode.com/users", GotNames)
 ]
 ```
 


### PR DESCRIPTION
The url should point to the users resource instead of posts