### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/api/h.md
+++ b/docs/api/h.md
@@ -131,7 +131,7 @@ The [classes](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attribute
 
 #### `style:`
 
-The [inline CSS styles](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/style) to use with the VNode. The `style` prop can be an object of [CSS properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference) where the keys are the CSS property names and the values are the correpsonding CSS property values. Hyphenated CSS property names can either be in camelCase or quoted to abide by JavaScript syntax restrictions.
+The [inline CSS styles](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/style) to use with the VNode. The `style` prop can be an object of [CSS properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference) where the keys are the CSS property names and the values are the corresponding CSS property values. Hyphenated CSS property names can either be in camelCase or quoted to abide by JavaScript syntax restrictions.
 
 ```js
 h(

--- a/docs/architecture/state.md
+++ b/docs/architecture/state.md
@@ -48,7 +48,7 @@ The primary [view](views.md) of your app, as set by the [`view:`](../api/app.md#
 
 ### Serializability
 
-While you can put anything you want in the state we recommend avoiding things that are unserializable such as symbols, functions, and recursive references. This helps to ensure compatibility with things like saving to peristent local storage, or using other tools especially ones that are potentially Hyperapp-specific.
+While you can put anything you want in the state we recommend avoiding things that are unserializable such as symbols, functions, and recursive references. This helps to ensure compatibility with things like saving to persistent local storage, or using other tools especially ones that are potentially Hyperapp-specific.
 
 ### State Type
 

--- a/docs/architecture/subscriptions.md
+++ b/docs/architecture/subscriptions.md
@@ -186,7 +186,7 @@ const listenToEvent = (dispatch, { action, type }) => {
 
 The reason is because destructuring the `props` parameter will create local copies of the props listed. This means the cleanup function's closure will be referring to the `action` function that existed at the moment the cleanup function was created and returned, not the moment the cleanup function gets invoked. This is a subtle yet significant difference depending on how you use your actions with this type of subscriber.
 
-The scenario in which this comes into play is if you use an anonymous function for the `action`. An example of where you may consider doing this is if you wanted a way to seletively prevent default event behavior when a subscriber responds to an event.
+The scenario in which this comes into play is if you use an anonymous function for the `action`. An example of where you may consider doing this is if you wanted a way to selectively prevent default event behavior when a subscriber responds to an event.
 
 ```js
 // ./fx.js

--- a/docs/architecture/views.md
+++ b/docs/architecture/views.md
@@ -200,6 +200,6 @@ For an example, look at the documentation for [`memo()`](../api/memo.md#example)
 
 Memoization exists to help improve rendering performance but it's not a panacea. If it was used with nodes that need to update on every state change, the cost of checking if the memoization's props had changed before carrying out the rendering would be a net loss of performance over time.
 
-Memoization was designed for nodes that don't need to update at all or just occassionally.
+Memoization was designed for nodes that don't need to update at all or just occasionally.
 
 As always when it comes to optimizations, be sure to measure the performance of your app to make sure you're getting true benefits and adjust if necessary.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -16,7 +16,7 @@
 - [Subscriptions](architecture/subscriptions.md) dispatch actions in response to external events.
 - [Dispatch](architecture/dispatch.md) controls action dispatching.
 
-&nbsp;&nbsp;&nbsp;&nbsp;[Flowchart](architecture/flowchart.md) showing the genral flow of a hyperapp app.
+&nbsp;&nbsp;&nbsp;&nbsp;[Flowchart](architecture/flowchart.md) showing the general flow of a hyperapp app.
 
 <h2 title="“I’d like to think of browsing the glossary as flipping pages in a book. I can go anywhere instantly and learn whatever suits my fancy.” ―@icylace">Glossary</h2>
 


### PR DESCRIPTION
There are small typos in:
- docs/api/h.md
- docs/architecture/state.md
- docs/architecture/subscriptions.md
- docs/architecture/views.md
- docs/reference.md

Fixes:
- Should read `selectively` rather than `seletively`.
- Should read `persistent` rather than `peristent`.
- Should read `occasionally` rather than `occassionally`.
- Should read `general` rather than `genral`.
- Should read `corresponding` rather than `correpsonding`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md