### PR TITLE
docs: Fix a typo in Components Returning Multiple VNodes example section

### DIFF
--- a/docs/architecture/views.md
+++ b/docs/architecture/views.md
@@ -120,7 +120,7 @@ const finishingMoveOptions = () => [
   h("button", { onclick: BefriendHim }, text("Friendship")),
 ]
 
-const view = () => h("div", {}, finishingMoveOptions())
+const view = () => h("div", {}, ...finishingMoveOptions())
 ```
 
 <!-- In the "Mortal Kombat" videogame series there are multiple ways to finish off your opponent. The opportunity to do so occurs at the end of a match once the match announcer exclaims "Finish Him!" -->


### PR DESCRIPTION
I think I've found a small typo in the docs in a section where there's a view that leverages a function returning multiple nodes.
It reads as:
> However, to make use of such components you'll need to spread their result.

But the example lists no apparent spread of the result:

> `const view = () => h("div", {}, finishingMoveOptions())`

I assume the intended line is: `...finishingMoveOptions()`? I'm doing a tiny project of mine and that seems to be the case.

