### PR TITLE
Enhance augmented dispatch examples

### DIFF
--- a/docs/architecture/dispatch.md
+++ b/docs/architecture/dispatch.md
@@ -93,7 +93,7 @@ const logStateMiddleware = stateMiddleware(state => {
 
 ## Example 3 - Immutable state
 
-When learning HyperApp and during developemt it can sometimes be useful to guarantee states are not mutated by mistake, let's use `stateMiddleware` above to create an augmented dispatch for state immutability:
+When learning Hyperapp and during developemt it can sometimes be useful to guarantee states are not mutated by mistake, let's use `stateMiddleware` above to create an augmented dispatch for state immutability:
 
 ```js
 // a proxy prohibiting mutation

--- a/docs/architecture/dispatch.md
+++ b/docs/architecture/dispatch.md
@@ -75,6 +75,7 @@ To log each state transformation, we first create a general state middleware and
 
 ```js
 const stateMiddleware = fn => dispatch => (action, payload) => {
+  if (!action) return dispatch();
   if (Array.isArray(action) && typeof action[0] !== 'function') {
     action = [fn(action[0]), ...action.slice(1)]
   } else if (!Array.isArray(action) && typeof action !== 'function') {

--- a/docs/architecture/dispatch.md
+++ b/docs/architecture/dispatch.md
@@ -128,14 +128,14 @@ import { mwLogState } from "./middleware.js"
 
 app({
   // ...
-  dispatch: logStateMiddleware
+  dispatch: logActionsMiddleware
 })
 ```
 
 And if you wanted to use all custom dispatches together, you can chain them like this:
 
 ```js
-import { mwLogState, mwLogActions } from "./middleware.js"
+import { logActionsMiddleware, logStateMiddleware, immutableMiddleware } from "./middleware.js"
 
 app({
   // ...

--- a/docs/architecture/dispatch.md
+++ b/docs/architecture/dispatch.md
@@ -59,7 +59,7 @@ Let's say you need to debug the order in which actions are dispatched. An augmen
 const logActionsMiddleware = dispatch => (action, payload) => {
 
   if (typeof action === 'function') {
-    console.log('DISPATCH: ', action.name)
+    console.log('DISPATCH: ', action.name || action)
   }
 
   //pass on to original dispatch

--- a/docs/architecture/dispatch.md
+++ b/docs/architecture/dispatch.md
@@ -84,7 +84,10 @@ const stateMiddleware = fn => dispatch => (action, payload) => {
   dispatch(action, payload)
 }
 
-const logStateMiddleware = stateMiddleware(state => { console.log(state); return state})
+const logStateMiddleware = stateMiddleware(state => { 
+  console.log('STATE:', state)
+  return state
+})
 ```
 
 

--- a/docs/architecture/dispatch.md
+++ b/docs/architecture/dispatch.md
@@ -93,7 +93,7 @@ const logStateMiddleware = stateMiddleware(state => {
 
 ## Example 3 - Immutable state
 
-When learning HyperApp and during the developemt it can sometimes be useful to guarantee states are not mutated by mistake, let's use `stateMiddleware` above to create an augmented dispatch for state immutability:
+When learning HyperApp and during developemt it can sometimes be useful to guarantee states are not mutated by mistake, let's use `stateMiddleware` above to create an augmented dispatch for state immutability:
 
 ```js
 // a proxy prohibiting mutation

--- a/docs/architecture/dispatch.md
+++ b/docs/architecture/dispatch.md
@@ -75,7 +75,6 @@ To log each state transformation, we first create a general state middleware and
 
 ```js
 const stateMiddleware = fn => dispatch => (action, payload) => {
-  if (!action) return dispatch();
   if (Array.isArray(action) && typeof action[0] !== 'function') {
     action = [fn(action[0]), ...action.slice(1)]
   } else if (!Array.isArray(action) && typeof action !== 'function') {

--- a/docs/architecture/dispatch.md
+++ b/docs/architecture/dispatch.md
@@ -77,8 +77,7 @@ If you instead are more interested in just logging each state transformation, an
 const stateMiddleware = fn => dispatch => (action, payload) => {
   if (Array.isArray(action) && typeof action[0] !== 'function') {
     action = [fn(action[0]), ...action.slice(1)]
-  }
-  if (!Array.isArray(action) && typeof action !== 'function') {
+  } else if (!Array.isArray(action) && typeof action !== 'function') {
     action = fn(action)
   }
   dispatch(action, payload)


### PR DESCRIPTION
I propose enhancement to the augmented dispatch examples:

- changed example 1 to handle case where action is defined inline

- change example 2 to separate `stateMiddleware` which can be useful in other scenarios (ie immutability) and then uses it for logging in `logStateMiddleware`. (credit to @zaceno for `stateMiddleware`)

- added example 3 that uses `stateMiddleware` for an augmented dispatch for immutability which can be invaluable when starting in HA or during development

