### PR TITLE
Ignore return value of unsubscribe handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ var patchSubs = (oldSubs, newSubs = EMPTY_ARR, dispatch) => {
               (oldSub && oldSub[2](), newSub[0](dispatch, newSub[1])),
             ]
           : oldSub
-        : oldSub && oldSub[2]()
+        : (oldSub && oldSub[2](), false)
     )
   }
   return subs


### PR DESCRIPTION
It is silently assumed unsubscribe handler has not return value, however if it has it compromises subscriptions processing. To make the code more robust I propose to ignore the return value and push into `subs` always `false` _(it would work with `unsubscribe` too, but `false` is shorter ;)_